### PR TITLE
Change define symbol for debug, fix missing debug block

### DIFF
--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -139,7 +139,7 @@ namespace ILRuntime.CLR.Method
                 isDelegateInvoke = true;
             this.appdomain = domain;
             paramCnt = def.HasParameters ? def.Parameters.Count : 0;
-#if DEBUG
+#if ILRUNTIME_DEBUG
             if (def.HasBody)
             {
                 var sp = DebugService.FindSequencePoint(def.Body.Instructions[0]);

--- a/ILRuntime/Runtime/Debugger/DebugService.cs
+++ b/ILRuntime/Runtime/Debugger/DebugService.cs
@@ -30,7 +30,7 @@ namespace ILRuntime.Runtime.Debugger
         {
             get
             {
-#if DEBUG
+#if ILRUNTIME_DEBUG
                 return (server != null && server.IsAttached);
 #else
                 return false;
@@ -49,7 +49,7 @@ namespace ILRuntime.Runtime.Debugger
         /// <param name="port">Port to listen on</param>
         public void StartDebugService(int port)
         {
-#if DEBUG
+#if ILRUNTIME_DEBUG
             server = new Debugger.DebuggerServer(this);
             server.Port = port;
             server.Start();
@@ -61,7 +61,7 @@ namespace ILRuntime.Runtime.Debugger
         /// </summary>
         public void StopDebugService()
         {
-#if DEBUG
+#if ILRUNTIME_DEBUG
             server.Stop();
             server = null;
 #endif

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -352,7 +352,7 @@ namespace ILRuntime.Runtime.Enviorment
                 objectType = GetType("System.Object");
             }
             module.AssemblyResolver.ResolveFailure += AssemblyResolver_ResolveFailure;
-#if DEBUG
+#if ILRUNTIME_DEBUG
             debugService.NotifyModuleLoaded(module.Name);
 #endif
         }
@@ -900,7 +900,7 @@ namespace ILRuntime.Runtime.Enviorment
                     else
                     {
                         inteptreter = new ILIntepreter(this);
-#if DEBUG
+#if ILRUNTIME_DEBUG
                         intepreters[inteptreter.GetHashCode()] = inteptreter;
                         debugService.ThreadStarted(inteptreter);
 #endif
@@ -914,7 +914,7 @@ namespace ILRuntime.Runtime.Enviorment
                 {
                     lock (freeIntepreters)
                     {
-#if DEBUG
+#if ILRUNTIME_DEBUG
                         if(inteptreter.CurrentStepType!= StepTypes.None)
                         {
                             //We should resume all other threads if we are currently doing stepping operation
@@ -932,7 +932,7 @@ namespace ILRuntime.Runtime.Enviorment
                         inteptreter.Stack.ManagedStack.Clear();
                         inteptreter.Stack.Frames.Clear();
                         freeIntepreters.Enqueue(inteptreter);
-#if DEBUG
+#if ILRUNTIME_DEBUG
                         //debugService.ThreadEnded(inteptreter);
 #endif
 

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -31,7 +31,7 @@ namespace ILRuntime.Runtime.Intepreter
             this.domain = domain;
             stack = new RuntimeStack(this);
             allowUnboundCLRMethod = domain.AllowUnboundCLRMethod;
-#if DEBUG
+#if ILRUNTIME_DEBUG
             _lockObj = new object();
 #endif
         }
@@ -187,7 +187,7 @@ namespace ILRuntime.Runtime.Intepreter
                 {
                     try
                     {
-#if DEBUG
+#if ILRUNTIME_DEBUG
                         if (ShouldBreak)
                             Break();
                         var insOffset = (int)(ip - ptr);
@@ -1724,7 +1724,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                     esp = redirect(this, esp, mStack, cm, false);
                                                 else
                                                 {
-#if DEBUG
+#if ILRUNTIME_DEBUG
                                                     if (!allowUnboundCLRMethod)
                                                         throw new NotSupportedException(cm.ToString() + " is not bound!");
 #endif
@@ -3676,6 +3676,7 @@ namespace ILRuntime.Runtime.Intepreter
                                 }
                                 else
                                 {
+#if ILRUNTIME_DEBUG
                                     var debugger = AppDomain.DebugService;
                                     if (method.HasThis)
                                         ex.Data["ThisInfo"] = debugger.GetThisInfo(this);
@@ -3683,6 +3684,7 @@ namespace ILRuntime.Runtime.Intepreter
                                         ex.Data["ThisInfo"] = "";
                                     ex.Data["StackTrace"] = debugger.GetStackTrance(this);
                                     ex.Data["LocalInfo"] = debugger.GetLocalVariableInfo(this);
+#endif
                                 }
                                 //Clear call stack
                                 while (stack.Frames.Peek().BasePointer != frame.BasePointer)
@@ -3708,7 +3710,7 @@ namespace ILRuntime.Runtime.Intepreter
 
                         unhandledException = true;
                         returned = true;
-#if DEBUG
+#if ILRUNTIME_DEBUG
                         if (!AppDomain.DebugService.Break(this, ex))
 #endif
                         {

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2859,7 +2859,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                 }
                                                 else
                                                 {
-#if !DEBUG
+#if !ILRUNTIME_DEBUG
                                                     objRef->ObjectType = ObjectTypes.Null;
                                                     objRef->Value = -1;
                                                     objRef->ValueLow = 0;
@@ -2874,7 +2874,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                 }
                                                 else
                                                 {
-#if !DEBUG
+#if !ILRUNTIME_DEBUG
                                                     objRef->ObjectType = ObjectTypes.Null;
                                                     objRef->Value = -1;
                                                     objRef->ValueLow = 0;
@@ -2884,7 +2884,7 @@ namespace ILRuntime.Runtime.Intepreter
                                         }
                                         else
                                         {
-#if !DEBUG
+#if !ILRUNTIME_DEBUG
                                                 objRef->ObjectType = ObjectTypes.Null;
                                                 objRef->Value = -1;
                                                 objRef->ValueLow = 0;
@@ -4293,7 +4293,8 @@ namespace ILRuntime.Runtime.Intepreter
                 if (esp->Value == stack.ManagedStack.Count - 1)
                     stack.ManagedStack.RemoveAt(esp->Value);
             }
-#if DEBUG
+
+#if ILRUNTIME_DEBUG
             esp->ObjectType = ObjectTypes.Null;
             esp->Value = -1;
             esp->ValueLow = 0;

--- a/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
+++ b/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
@@ -25,12 +25,14 @@ namespace ILRuntime.Runtime.Intepreter
             }
             else
             {
+#if ILRUNTIME_DEBUG
                 stackTrace = ds.GetStackTrance(intepreter);
                 if (method.HasThis)
                     thisInfo = ds.GetThisInfo(intepreter);
                 else
                     thisInfo = "";
                 localInfo = ds.GetLocalVariableInfo(intepreter);
+#endif
             }
         }
 

--- a/ILRuntime/Runtime/Stack/RuntimeStack.cs
+++ b/ILRuntime/Runtime/Stack/RuntimeStack.cs
@@ -52,7 +52,7 @@ namespace ILRuntime.Runtime.Stack
             res = new StackFrame();
             res.LocalVarPointer = esp;
             res.Method = method;
-#if DEBUG
+#if ILRUNTIME_DEBUG
             res.Address = new IntegerReference();
             for (int i = 0; i < method.LocalVariableCount; i++)
             {


### PR DESCRIPTION
This PR changes the `DEBUG` define, which is always on in the Unity editor, to be `ILRUNTIME_DEBUG` so it can be turned off. It also adds what looked to be missing #if blocks.