### PR TITLE
Clear stack regardless of if in debug mode

### DIFF
--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -4291,11 +4291,10 @@ namespace ILRuntime.Runtime.Intepreter
                 if (esp->Value == stack.ManagedStack.Count - 1)
                     stack.ManagedStack.RemoveAt(esp->Value);
             }
-#if DEBUG
+
             esp->ObjectType = ObjectTypes.Null;
             esp->Value = -1;
             esp->ValueLow = 0;
-#endif
         }
     }
 }


### PR DESCRIPTION
This fixes what I think may have been a bug (I get errors otherwise) where the top of the stack is not cleared out unless in Debug mode. I am not sure if this is a bug directly or is exposing some other underlying problem. If this patch is not applied and Debug mode is disabled, then I get an exception on array bounds when running a simple script. (Happy to investigate further if this patch looks incorrect.)