### PR TITLE
Feature/misc optimizations

### DIFF
--- a/ILRuntime/CLR/TypeSystem/ILType.cs
+++ b/ILRuntime/CLR/TypeSystem/ILType.cs
@@ -549,14 +549,18 @@ namespace ILRuntime.CLR.TypeSystem
         public IMethod GetVirtualMethod(IMethod method)
         {
             IType[] genericArguments = null;
-            if (method is ILMethod)
+            if (method.IsGenericInstance)
             {
-                genericArguments = ((ILMethod)method).GenericArugmentsArray;
+                if (method is ILMethod)
+                {
+                    genericArguments = ((ILMethod)method).GenericArugmentsArray;
+                }
+                else
+                {
+                    genericArguments = ((CLRMethod)method).GenericArguments;
+                }
             }
-            else
-            {
-                genericArguments = ((CLRMethod)method).GenericArguments;
-            }
+
             var m = GetMethod(method.Name, method.Parameters, genericArguments, method.ReturnType);
             if (m == null)
             {
@@ -581,8 +585,9 @@ namespace ILRuntime.CLR.TypeSystem
             IMethod genericMethod = null;
             if (methods.TryGetValue(name, out lst))
             {
-                foreach (var i in lst)
+                for (var idx = 0; idx < lst.Count; idx++)
                 {
+                    var i = lst[idx];
                     int pCnt = param != null ? param.Count : 0;
                     if (i.ParameterCount == pCnt)
                     {

--- a/ILRuntime/CLR/TypeSystem/ILType.cs
+++ b/ILRuntime/CLR/TypeSystem/ILType.cs
@@ -255,11 +255,16 @@ namespace ILRuntime.CLR.TypeSystem
             get; private set;
         }
 
+        private bool? isValueType;
+
         public bool IsValueType
         {
             get
             {
-                return definition.IsValueType;
+                if (isValueType == null)
+                    isValueType = definition.IsValueType;
+
+                return isValueType.Value;
             }
         }
 

--- a/ILRuntime/Runtime/Stack/RuntimeStack.cs
+++ b/ILRuntime/Runtime/Stack/RuntimeStack.cs
@@ -76,11 +76,12 @@ namespace ILRuntime.Runtime.Stack
             else
                 throw new NotSupportedException();
             StackObject* returnVal = esp - 1;
-            StackObject* ret = frame.LocalVarPointer - frame.Method.ParameterCount;
+            var method = frame.Method;
+            StackObject* ret = frame.LocalVarPointer - method.ParameterCount;
             int mStackBase = frame.ManagedStackBase;
-            if (frame.Method.HasThis)
+            if (method.HasThis)
                 ret--;
-            if(frame.Method.ReturnType != intepreter.AppDomain.VoidType)
+            if(method.ReturnType != intepreter.AppDomain.VoidType)
             {
                 *ret = *returnVal;
                 if(ret->ObjectType == ObjectTypes.Object)


### PR DESCRIPTION
This PR adds a few small optimizations:

- Memoizes `ILType#IsValueType`
- Skips generic parameter lookup for non-generic types in `ILType#GetMethod`
- Removes memory allocation of `foreach` enumerator in `ILType#GetMethod`
- Extracts common subexpression in `RuntimeStack#PushFrame`
