### PR TITLE
fix custom attributes compare bug

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
@@ -154,14 +154,10 @@ namespace ILRuntime.Reflection
             if (customAttributes == null)
                 InitializeCustomAttribute();
 
-            var typeFullName = attributeType.FullName;
-
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                var fullName = attributeTypes[i].FullName;
-
-                if (fullName == typeFullName)
+                if (attributeTypes[i].Equals(attributeType))
                 {
                     res.Add(customAttributes[i]);
                 }
@@ -195,13 +191,10 @@ namespace ILRuntime.Reflection
             if (customAttributes == null)
                 InitializeCustomAttribute();
 
-            var typeFullName = attributeType.FullName;
 
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                var fullName = attributeTypes[i].FullName;
-
-                if (fullName == typeFullName)
+                if (attributeTypes[i].Equals(attributeType))
                 {
                     return true;
                 }

--- a/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
@@ -153,11 +153,18 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
+
+            var typeFullName = attributeType.FullName;
+
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                var fullName = attributeTypes[i].FullName;
+
+                if (fullName == typeFullName)
+                {
                     res.Add(customAttributes[i]);
+                }
             }
             return res.ToArray();
         }
@@ -187,10 +194,17 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
+
+            var typeFullName = attributeType.FullName;
+
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                var fullName = attributeTypes[i].FullName;
+
+                if (fullName == typeFullName)
+                {
                     return true;
+                }
             }
             return false;
         }

--- a/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
@@ -162,11 +162,18 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
+
+            var typeFullName = attributeType.FullName;
+
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                var fullName = attributeTypes[i].FullName;
+
+                if (fullName == typeFullName)
+                {
                     res.Add(customAttributes[i]);
+                }
             }
             return res.ToArray();
         }
@@ -175,10 +182,17 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
+
+            var typeFullName = attributeType.FullName;
+
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                var fullName = attributeTypes[i].FullName;
+
+                if (fullName == typeFullName)
+                {
                     return true;
+                }
             }
             return false;
         }

--- a/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
@@ -163,14 +163,10 @@ namespace ILRuntime.Reflection
             if (customAttributes == null)
                 InitializeCustomAttribute();
 
-            var typeFullName = attributeType.FullName;
-
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                var fullName = attributeTypes[i].FullName;
-
-                if (fullName == typeFullName)
+                if (attributeTypes[i].Equals(attributeType))
                 {
                     res.Add(customAttributes[i]);
                 }
@@ -183,13 +179,9 @@ namespace ILRuntime.Reflection
             if (customAttributes == null)
                 InitializeCustomAttribute();
 
-            var typeFullName = attributeType.FullName;
-
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                var fullName = attributeTypes[i].FullName;
-
-                if (fullName == typeFullName)
+                if (attributeTypes[i].Equals(attributeType))
                 {
                     return true;
                 }

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -21,7 +21,7 @@ namespace ILRuntime.Reflection
         ILRuntimeMethodInfo[] methods;
 
         public ILType ILType { get { return type; } }
-        
+
         public ILRuntimeType(ILType t)
         {
             type = t;
@@ -46,7 +46,7 @@ namespace ILRuntime.Reflection
                 catch
                 {
                     attributeTypes[i] = typeof(Attribute);
-                }               
+                }
             }
 
         }
@@ -191,7 +191,7 @@ namespace ILRuntime.Reflection
             List<object> res = new List<object>();
             for(int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                if (attributeTypes[i].Equals(attributeType))
                     res.Add(customAttributes[i]);
             }
             return res.ToArray();
@@ -289,7 +289,7 @@ namespace ILRuntime.Reflection
             }
             for (int i = methods.Length + fields.Length; i < res.Length; i++)
             {
-                res[i] = properties[i- methods.Length - fields.Length];
+                res[i] = properties[i - methods.Length - fields.Length];
             }
 
             return res;
@@ -343,7 +343,7 @@ namespace ILRuntime.Reflection
                 InitializeCustomAttribute();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                if (attributeTypes[i].Equals(attributeType))
                     return true;
             }
             return false;

--- a/ILRuntimeTest/ILRuntimeTest.csproj
+++ b/ILRuntimeTest/ILRuntimeTest.csproj
@@ -120,6 +120,7 @@
     <Compile Include="AutoGenerate\System_Reflection_MethodBase_Binding.cs" />
     <Compile Include="AutoGenerate\System_String_Binding.cs" />
     <Compile Include="AutoGenerate\System_Type_Binding.cs" />
+    <Compile Include="TestFramework\TestCLRAttribute.cs" />
     <Compile Include="TestFramework\TestVector3.cs" />
     <Compile Include="TestFramework\TestCLREnum.cs" />
     <Compile Include="TestMainForm.cs">

--- a/ILRuntimeTest/TestFramework/TestCLRAttribute.cs
+++ b/ILRuntimeTest/TestFramework/TestCLRAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace ILRuntimeTest.TestFramework
+{
+    [AttributeUsage(AttributeTargets.All)]
+    public class TestCLRAttribute : Attribute
+    {
+        
+    }
+}

--- a/TestCases/ReflectionTest.cs
+++ b/TestCases/ReflectionTest.cs
@@ -50,7 +50,7 @@ namespace TestCases
                 TestAttribute a = (TestAttribute)i;
                 Console.WriteLine(a.TestProp);
             }
-            
+
             arr = typeof(TestCls).GetCustomAttributes(false);
             foreach (var i in arr)
             {
@@ -96,6 +96,59 @@ namespace TestCases
             Console.WriteLine(SingletonTest.Inst.testFloat);
         }
 
+        public static void ReflectionTest07()
+        {
+            //-----------------------------CLR-----------------------------//
+            var isDefined = typeof(TestCls2).IsDefined(typeof(ObsoleteAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 1");
+            }
+
+            isDefined = typeof(TestCls2).GetProperty("Attribute_prop").IsDefined(typeof(TestCLRAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 2");
+            }
+
+            isDefined = typeof(TestCls2).GetField("Attribute_field").IsDefined(typeof(TestCLRAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 3");
+            }
+        }
+
+        public static void ReflectionTest08()
+        {
+            //-----------------------------CLR-----------------------------//
+            var isDefined = typeof(TestCls2).IsDefined(typeof(TestAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 1");
+            }
+
+            isDefined = typeof(TestCls2).GetProperty("ILAttribute_prop").IsDefined(typeof(TestAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 2");
+            }
+
+            isDefined = typeof(TestCls2).GetField("ILAttribute_field").IsDefined(typeof(TestAttribute), true);
+
+            if (isDefined == false)
+            {
+                throw new Exception("isDefeinded == false 3");
+            }
+        }
+
+
+
+
         [Obsolete("gasdgas")]
         class TestCls
         {
@@ -118,11 +171,24 @@ namespace TestCases
             }
         }
 
+        
+        [Serializable]
+        [Obsolete]
         [Test(true, TestProp = "1234")]
         [Test]
-        [Serializable]
-        class TestCls2
+        public class TestCls2
         {
+            [TestCLR]
+            public int Attribute_field;
+
+            [Test]
+            public int ILAttribute_field;
+
+            [TestCLR]
+            public int Attribute_prop { get; set; }
+
+            [Test]
+            public int ILAttribute_prop { get; set; }
 
         }
 


### PR DESCRIPTION
(ILRuntimeWrapperType)attributeTypes[i] == (System.RuntimeType)attributeType 不能正常工作

直接调用==对比了ILRuntimeWrapperType和System.RuntimeType的HashCode。结果始终为false。
手动调用Equals(Type)会对比UnderlyingSystemType。就不会有这种问题了