### PR TITLE
 Avoid warnings in Unity.

### DIFF
--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -184,9 +184,10 @@ namespace ILRuntime.Runtime.Generated
                     oFileName = oFileName + "_t";
                 files.Add(oFileName);
                 oFileName = oFileName + ".cs";
-                using (System.IO.StreamWriter sw = new System.IO.StreamWriter(oFileName, false, Encoding.UTF8))
+                using (System.IO.StreamWriter sw = new System.IO.StreamWriter(oFileName, false, new UTF8Encoding(false)))
                 {
-                    sw.Write(@"using System;
+                    StringBuilder sb = new StringBuilder();
+                    sb.Append(@"using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -202,17 +203,17 @@ using ILRuntime.CLR.Utils;
 namespace ILRuntime.Runtime.Generated
 {
     unsafe class ");
-                    sw.WriteLine(clsName);
-                    sw.Write(@"    {
+                    sb.AppendLine(clsName);
+                    sb.Append(@"    {
         public static void Register(ILRuntime.Runtime.Enviorment.AppDomain app)
         {
-            BindingFlags flag = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
-            MethodBase method;
-            FieldInfo field;
-            Type[] args;
-            Type type = typeof(");
-                    sw.Write(realClsName);
-                    sw.WriteLine(");");
+");
+                    string flagDef =    "            BindingFlags flag = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;";
+                    string methodDef =  "            MethodBase method;";
+                    string fieldDef =   "            FieldInfo field;";
+                    string argsDef =    "            Type[] args;";
+                    string typeDef = string.Format("            Type type = typeof({0});", realClsName);
+
                     MethodInfo[] methods = info.Value.Methods.ToArray();
                     FieldInfo[] fields = info.Value.Fields.ToArray();
                     string registerMethodCode = i.GenerateMethodRegisterCode(methods, excludeMethods);
@@ -231,33 +232,55 @@ namespace ILRuntime.Runtime.Generated
                         var fs = i.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                         cloneWraperCode = i.GenerateCloneWraperCode(fs, realClsName);
                     }
-                    string ctorWraperCode = i.GenerateConstructorWraperCode(ctors, realClsName, excludeMethods);
-                    sw.WriteLine(registerMethodCode);
+
+                    bool hasMethodCode = !string.IsNullOrEmpty(registerMethodCode);
+                    bool hasFieldCode = !string.IsNullOrEmpty(registerFieldCode);
+                    bool hasValueTypeCode = !string.IsNullOrEmpty(registerValueTypeCode);
+                    bool hasMiscCode = !string.IsNullOrEmpty(registerMiscCode);
+                    bool hasCtorCode = !string.IsNullOrEmpty(ctorRegisterCode);
+                    bool hasNormalMethod = methods.Where(x => !x.IsGenericMethod).Count() != 0;
+
+                    if ((hasMethodCode && hasNormalMethod) || hasFieldCode || hasCtorCode)
+                        sb.AppendLine(flagDef);
+                    if (hasMethodCode || hasCtorCode)
+                        sb.AppendLine(methodDef);
+                    if (hasFieldCode)
+                        sb.AppendLine(fieldDef);
+                    if (hasMethodCode || hasFieldCode || hasCtorCode)
+                        sb.AppendLine(argsDef);
+                    if (hasMethodCode || hasFieldCode || hasValueTypeCode || hasMiscCode || hasCtorCode)
+                        sb.AppendLine(typeDef);
+
+                    sb.AppendLine(registerMethodCode);
                     if (fields.Length > 0)
-                        sw.WriteLine(registerFieldCode);
+                        sb.AppendLine(registerFieldCode);
                     if (info.Value.ValueTypeNeeded)
-                        sw.WriteLine(registerValueTypeCode);
+                        sb.AppendLine(registerValueTypeCode);
                     if (!string.IsNullOrEmpty(registerMiscCode))
-                        sw.WriteLine(registerMiscCode);
-                    sw.WriteLine(ctorRegisterCode);
-                    sw.WriteLine("        }");
-                    sw.WriteLine();
-                    sw.WriteLine(commonCode);
-                    sw.WriteLine(methodWraperCode);
+                        sb.AppendLine(registerMiscCode);
+                    sb.AppendLine(ctorRegisterCode);
+                    sb.AppendLine("        }");
+                    sb.AppendLine();
+                    sb.AppendLine(commonCode);
+                    sb.AppendLine(methodWraperCode);
                     if (fields.Length > 0)
-                        sw.WriteLine(fieldWraperCode);
+                        sb.AppendLine(fieldWraperCode);
                     if (info.Value.ValueTypeNeeded)
-                        sw.WriteLine(cloneWraperCode);
-                    sw.WriteLine(ctorWraperCode);
-                    sw.WriteLine("    }");
-                    sw.WriteLine("}");
+                        sb.AppendLine(cloneWraperCode);
+                    string ctorWraperCode = i.GenerateConstructorWraperCode(ctors, realClsName, excludeMethods);
+                    sb.AppendLine(ctorWraperCode);
+                    sb.AppendLine("    }");
+                    sb.AppendLine("}");
+
+                    sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
                     sw.Flush();
                 }
             }
 
-            using (System.IO.StreamWriter sw = new System.IO.StreamWriter(outputPath + "/CLRBindings.cs", false, Encoding.UTF8))
+            using (System.IO.StreamWriter sw = new System.IO.StreamWriter(outputPath + "/CLRBindings.cs", false, new UTF8Encoding(false)))
             {
-                sw.WriteLine(@"using System;
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine(@"using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -272,14 +295,15 @@ namespace ILRuntime.Runtime.Generated
         {");
                 foreach (var i in clsNames)
                 {
-                    sw.Write("            ");
-                    sw.Write(i);
-                    sw.WriteLine(".Register(app);");
+                    sb.Append("            ");
+                    sb.Append(i);
+                    sb.AppendLine(".Register(app);");
                 }
 
-                sw.WriteLine(@"        }
+                sb.AppendLine(@"        }
     }
 }");
+                sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
             }
         }
 

--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using ILRuntime.Runtime.Enviorment;
 using ILRuntime.Other;
 
@@ -106,7 +107,7 @@ namespace ILRuntime.Runtime.Generated
                     sb.AppendLine("    }");
                     sb.AppendLine("}");
 
-                    sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
+                    sw.Write(Regex.Replace(sb.ToString(), "(?<!\r)\n", "\r\n"));
                     sw.Flush();
                 }
             }
@@ -137,7 +138,7 @@ namespace ILRuntime.Runtime.Generated
                 sb.AppendLine(@"        }
     }
 }");
-                sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
+                sw.Write(Regex.Replace(sb.ToString(), "(?<!\r)\n", "\r\n"));
             }
         }
 
@@ -297,7 +298,7 @@ namespace ILRuntime.Runtime.Generated
                     sb.AppendLine("    }");
                     sb.AppendLine("}");
 
-                    sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
+                    sw.Write(Regex.Replace(sb.ToString(), "(?<!\r)\n", "\r\n"));
                     sw.Flush();
                 }
             }
@@ -328,7 +329,7 @@ namespace ILRuntime.Runtime.Generated
                 sb.AppendLine(@"        }
     }
 }");
-                sw.Write(sb.Replace("\r\n", "\n").Replace("\n", "\r\n"));
+                sw.Write(Regex.Replace(sb.ToString(), "(?<!\r)\n", "\r\n"));
             }
         }
 

--- a/ILRuntime/Runtime/CLRBinding/ConstructorBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/ConstructorBindingGenerator.cs
@@ -65,7 +65,8 @@ namespace ILRuntime.Runtime.CLRBinding
                 sb.AppendLine(string.Format("        static StackObject* Ctor_{0}(ILIntepreter __intp, StackObject* __esp, IList<object> __mStack, CLRMethod __method, bool isNewObj)", idx));
                 sb.AppendLine("        {");
                 sb.AppendLine("            ILRuntime.Runtime.Enviorment.AppDomain __domain = __intp.AppDomain;");
-                sb.AppendLine("            StackObject* ptr_of_this_method;");
+                if (param.Length != 0)
+                    sb.AppendLine("            StackObject* ptr_of_this_method;");
                 sb.AppendLine(string.Format("            StackObject* __ret = ILIntepreter.Minus(__esp, {0});", paramCnt));
                 for (int j = param.Length; j > 0; j--)
                 {

--- a/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
@@ -131,7 +131,8 @@ namespace ILRuntime.Runtime.CLRBinding
                 sb.AppendLine(string.Format("        static StackObject* {0}_{1}(ILIntepreter __intp, StackObject* __esp, IList<object> __mStack, CLRMethod __method, bool isNewObj)", i.Name, idx));
                 sb.AppendLine("        {");
                 sb.AppendLine("            ILRuntime.Runtime.Enviorment.AppDomain __domain = __intp.AppDomain;");
-                sb.AppendLine("            StackObject* ptr_of_this_method;");
+                if (param.Length != 0 || !i.IsStatic)
+                    sb.AppendLine("            StackObject* ptr_of_this_method;");
                 sb.AppendLine(string.Format("            StackObject* __ret = ILIntepreter.Minus(__esp, {0});", paramCnt));
                 for (int j = param.Length; j > 0; j--)
                 {


### PR DESCRIPTION
Avoid the following warnings in Unity:
There are inconsistent line endings in the 'xxx.cs' script. Some are Mac OS X (UNIX) and some are Windows.
warning CS0168: The variable `flag' is declared but never used
warning CS0168: The variable `method' is declared but never used
warning CS0168: The variable `field' is declared but never used
warning CS0168: The variable `args' is declared but never used
warning CS0168: The variable `ptr_of_this_method' is declared but never used