### PR TITLE
Update MethodBindingGenerator.cs

### DIFF
--- a/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
@@ -199,7 +199,10 @@ namespace ILRuntime.Runtime.CLRBinding
                 {
                     if (isProperty)
                     {
-                        string[] t = i.Name.Split('_');
+                        string[] t = new string[2];
+                        int firstUnderlineIndex = i.Name.IndexOf("_");
+                        t[0] = i.Name.Substring(0, firstUnderlineIndex);
+                        t[1] = i.Name.Substring(firstUnderlineIndex + 1);
                         string propType = t[0];
 
                         if (propType == "get")
@@ -286,7 +289,10 @@ namespace ILRuntime.Runtime.CLRBinding
                 {
                     if (isProperty)
                     {
-                        string[] t = i.Name.Split('_');
+                        string[] t = new string[2];
+                        int firstUnderlineIndex = i.Name.IndexOf("_");
+                        t[0] = i.Name.Substring(0, firstUnderlineIndex);
+                        t[1] = i.Name.Substring(firstUnderlineIndex + 1);
                         string propType = t[0];
 
                         if (propType == "get")


### PR DESCRIPTION
对于形如：string a_b_c = "test" ; 这样的属性，生成 属性的get, set 方法绑定时生成错误代码