### PR TITLE
Fix incorrect generated method

### DIFF
--- a/ILRuntime/CLR/Utils/Extensions.cs
+++ b/ILRuntime/CLR/Utils/Extensions.cs
@@ -8,6 +8,8 @@ using ILRuntime.CLR.Method;
 using ILRuntime.Other;
 using Mono.Cecil;
 using ILRuntime.Runtime.Intepreter;
+using System.Reflection;
+
 namespace ILRuntime.CLR.Utils
 {
     public delegate TResult Func<T1, T2, T3, T4, T5, TResult>(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5);
@@ -269,6 +271,18 @@ namespace ILRuntime.CLR.Utils
                 }
             }
             return obj;
+        }
+
+        public static bool CheckMethodParams(this MethodInfo m, Type[] args)
+        {
+            var arr = m.GetParameters();
+            if (arr.Length != args.Length) return false;
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (arr[i].ParameterType != args[i])
+                    return false;
+            }
+            return true;
         }
     }
 }

--- a/ILRuntime/CLR/Utils/Extensions.cs
+++ b/ILRuntime/CLR/Utils/Extensions.cs
@@ -279,7 +279,23 @@ namespace ILRuntime.CLR.Utils
             if (arr.Length != args.Length) return false;
             for (var i = 0; i < args.Length; i++)
             {
-                if (arr[i].ParameterType != args[i])
+                var t1 = arr[i].ParameterType;
+                var t2 = args[i];
+                if (t1 != t2 || t1.IsByRef != t2.IsByRef)
+                    return false;
+            }
+            return true;
+        }
+
+        public static bool CheckMethodParams(this MethodInfo m, ParameterInfo[] args)
+        {
+            var arr = m.GetParameters();
+            if (arr.Length != args.Length) return false;
+            for (var i = 0; i < args.Length; i++)
+            {
+                var t1 = arr[i].ParameterType;
+                var t2 = args[i].ParameterType;
+                if (t1 != t2 || t1.IsByRef != t2.IsByRef)
                     return false;
             }
             return true;

--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -61,13 +61,15 @@ namespace ILRuntime.Runtime.Generated
 ");
                     string flagDef = "            BindingFlags flag = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;";
                     string methodDef = "            MethodBase method;";
+                    string methodsDef = "            MethodInfo[] methods = type.GetMethods(flag).Where(t => !t.IsGenericMethod).ToArray();";
                     string fieldDef = "            FieldInfo field;";
                     string argsDef = "            Type[] args;";
                     string typeDef = string.Format("            Type type = typeof({0});", realClsName);
 
+                    bool needMethods;
                     MethodInfo[] methods = i.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                     FieldInfo[] fields = i.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
-                    string registerMethodCode = i.GenerateMethodRegisterCode(methods, excludeMethods);
+                    string registerMethodCode = i.GenerateMethodRegisterCode(methods, excludeMethods, out needMethods);
                     string registerFieldCode = i.GenerateFieldRegisterCode(fields, excludeFields);
                     string registerValueTypeCode = i.GenerateValueTypeRegisterCode(realClsName);
                     string registerMiscCode = i.GenerateMiscRegisterCode(realClsName, true, true);
@@ -96,6 +98,8 @@ namespace ILRuntime.Runtime.Generated
                         sb.AppendLine(argsDef);
                     if (hasMethodCode || hasFieldCode || hasValueTypeCode || hasMiscCode || hasCtorCode)
                         sb.AppendLine(typeDef);
+                    if (needMethods)
+                        sb.AppendLine(methodsDef);
 
 
                     sb.AppendLine(registerMethodCode);
@@ -233,9 +237,10 @@ namespace ILRuntime.Runtime.Generated
                     string argsDef =    "            Type[] args;";
                     string typeDef = string.Format("            Type type = typeof({0});", realClsName);
 
+                    bool needMethods;
                     MethodInfo[] methods = info.Value.Methods.ToArray();
                     FieldInfo[] fields = info.Value.Fields.ToArray();
-                    string registerMethodCode = i.GenerateMethodRegisterCode(methods, excludeMethods);
+                    string registerMethodCode = i.GenerateMethodRegisterCode(methods, excludeMethods, out needMethods);
                     string registerFieldCode = fields.Length > 0 ? i.GenerateFieldRegisterCode(fields, excludeFields) : null;
                     string registerValueTypeCode = info.Value.ValueTypeNeeded ? i.GenerateValueTypeRegisterCode(realClsName) : null;
                     string registerMiscCode = i.GenerateMiscRegisterCode(realClsName, info.Value.DefaultInstanceNeeded, info.Value.ArrayNeeded);
@@ -269,7 +274,7 @@ namespace ILRuntime.Runtime.Generated
                         sb.AppendLine(argsDef);
                     if (hasMethodCode || hasFieldCode || hasValueTypeCode || hasMiscCode || hasCtorCode)
                         sb.AppendLine(typeDef);
-                    if (hasMethodCode && hasNormalMethod)
+                    if (needMethods)
                         sb.AppendLine(methodsDef);
 
                     sb.AppendLine(registerMethodCode);

--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -206,6 +206,7 @@ namespace ILRuntime.Runtime.Generated
                     StringBuilder sb = new StringBuilder();
                     sb.Append(@"using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -227,6 +228,7 @@ namespace ILRuntime.Runtime.Generated
 ");
                     string flagDef =    "            BindingFlags flag = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;";
                     string methodDef =  "            MethodBase method;";
+                    string methodsDef = "            MethodInfo[] methods = type.GetMethods(flag).Where(t => !t.IsGenericMethod).ToArray();";
                     string fieldDef =   "            FieldInfo field;";
                     string argsDef =    "            Type[] args;";
                     string typeDef = string.Format("            Type type = typeof({0});", realClsName);
@@ -267,6 +269,8 @@ namespace ILRuntime.Runtime.Generated
                         sb.AppendLine(argsDef);
                     if (hasMethodCode || hasFieldCode || hasValueTypeCode || hasMiscCode || hasCtorCode)
                         sb.AppendLine(typeDef);
+                    if (hasMethodCode && hasNormalMethod)
+                        sb.AppendLine(methodsDef);
 
                     sb.AppendLine(registerMethodCode);
                     if (fields.Length > 0)

--- a/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Linq;
 using System.Text;
 using ILRuntime.Runtime.Enviorment;
+using ILRuntime.CLR.Utils;
 
 namespace ILRuntime.Runtime.CLRBinding
 {
@@ -114,9 +115,9 @@ namespace ILRuntime.Runtime.CLRBinding
                         needMethods = true;
                         sb.AppendLine(string.Format("            method = methods.Where(t => t.Name.Equals(\"{0}\") && t.ReturnType == typeof({1}) && t.CheckMethodParams(args)).Single();", i.Name, realClsName));
                     }
-                    else if (allMethods.Any(m => m.Name.Equals(i.Name) && m.IsGenericMethod))
+                    else if (allMethods.Any(m => m.IsGenericMethod && m.Name.Equals(i.Name) && m.CheckMethodParams(param)))
                     {
-                        // Check for a generic method with the same name
+                        // Check for a generic method with the same name and params
                         needMethods = true;
                         sb.AppendLine(string.Format("            method = methods.Where(t => t.Name.Equals(\"{0}\") && t.CheckMethodParams(args)).Single();", i.Name));
                     }else

--- a/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
@@ -103,7 +103,7 @@ namespace ILRuntime.Runtime.CLRBinding
                     }
                     sb2.Append("}");
                     sb.AppendLine(string.Format("            args = new Type[]{0};", sb2));
-                    sb.AppendLine(string.Format("            method = type.GetMethod(\"{0}\", flag, null, args, null);", i.Name));
+                    sb.AppendLine(string.Format("            method = methods.Where(t => t.Name.Equals(\"{0}\") && t.CheckMethodParams(args)).Single();", i.Name));
                     sb.AppendLine(string.Format("            app.RegisterCLRMethodRedirection(method, {0}_{1});", i.Name, idx));
                 }
 

--- a/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/MethodBindingGenerator.cs
@@ -11,6 +11,8 @@ namespace ILRuntime.Runtime.CLRBinding
     {
         internal static string GenerateMethodRegisterCode(this Type type, MethodInfo[] methods, HashSet<MethodBase> excludes)
         {
+            MethodInfo[] allMethods = type.GetMethods();
+            
             StringBuilder sb = new StringBuilder();
             int idx = 0;
             bool isMethodsGot = false;
@@ -103,7 +105,12 @@ namespace ILRuntime.Runtime.CLRBinding
                     }
                     sb2.Append("}");
                     sb.AppendLine(string.Format("            args = new Type[]{0};", sb2));
-                    sb.AppendLine(string.Format("            method = methods.Where(t => t.Name.Equals(\"{0}\") && t.CheckMethodParams(args)).Single();", i.Name));
+
+                    // Check for a generic method with the same name
+                    if (allMethods.Any(m => m.Name.Equals(i.Name) && m.IsGenericMethod))
+                        sb.AppendLine(string.Format("            method = methods.Where(t => t.Name.Equals(\"{0}\") && t.CheckMethodParams(args)).Single();", i.Name));
+                    else
+                        sb.AppendLine(string.Format("            method = type.GetMethod(\"{0}\", flag, null, args, null);", i.Name));
                     sb.AppendLine(string.Format("            app.RegisterCLRMethodRedirection(method, {0}_{1});", i.Name, idx));
                 }
 


### PR DESCRIPTION
Fix incorrect generated method

example:
~~~
class A
{
    public int MethodA(){};
    public T MethodA<T>(){};
}
~~~