### PR TITLE
fix CLR binding code is incorrect

### DIFF
--- a/ILRuntime/Runtime/Extensions.cs
+++ b/ILRuntime/Runtime/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -71,7 +71,7 @@ namespace ILRuntime.Runtime
             else
             {
                 clsName = simpleClassName ? "" : (!string.IsNullOrEmpty(type.Namespace) ? type.Namespace.Replace(".", "_") + "_" : "");
-                realNamespace = !string.IsNullOrEmpty(type.Namespace) ? type.Namespace + "." : null;
+                realNamespace = !string.IsNullOrEmpty(type.Namespace) ? type.Namespace + "." : "global::";
             }
             clsName = clsName + type.Name.Replace(".", "_").Replace("`", "_").Replace("<", "_").Replace(">", "_");
             bool isGeneric = false;


### PR DESCRIPTION
CLR binding code is incorrect when is namespace is the same as class name.

example:

~~~
// A.cs
public class A {}

// Test_A.cs
namespace test.A
{
    public class TA{}
}
~~~