### PR TITLE
DelegateAdapter重写了基类的Equals(object obj)方法

### DIFF
--- a/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
+++ b/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
@@ -1008,6 +1008,16 @@ namespace ILRuntime.Runtime.Intepreter
                 return false;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (obj is DelegateAdapter)
+            {
+                DelegateAdapter b = (DelegateAdapter)obj;
+                return instance == b.instance && method == b.method;
+            }
+            return false;
+        }
+
         public virtual bool Equals(Delegate dele)
         {
             return Delegate == dele;


### PR DESCRIPTION
在DelegateAdapter中重写了基类的Equals(object obj)方法，用于判断相等。否则在对定义在热更工程中的委托类型进行相等判断时（比如List.Contains），会因为调用到基类的Equals方法而抛出空引用