### PR TITLE
添加一个泛型扩展方法的测试用例，目前这个测试用例无法通过！

### DIFF
--- a/ILRuntimeTest/ILRuntimeTest.csproj
+++ b/ILRuntimeTest/ILRuntimeTest.csproj
@@ -161,6 +161,7 @@
     <Compile Include="AutoGenerate\System_Threading_Tasks_Task_1_Int32_Binding.cs" />
     <Compile Include="AutoGenerate\System_Threading_Tasks_Task_Binding.cs" />
     <Compile Include="AutoGenerate\System_Type_Binding.cs" />
+    <Compile Include="TestBase\GenericExtensions.cs" />
     <Compile Include="TestFramework\TestCLRAttribute.cs" />
     <Compile Include="TestFramework\TestVector3.cs" />
     <Compile Include="TestFramework\TestCLREnum.cs" />

--- a/ILRuntimeTest/TestBase/GenericExtensions.cs
+++ b/ILRuntimeTest/TestBase/GenericExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ILRuntimeTest.TestBase
+{
+    public class ExtensionClass { }
+
+    public class SubExtensionClass : ExtensionClass { }
+
+    public static class GenericExtensions
+    {
+        public static void ExtensionMethod<TException>(this ExtensionClass instance, TException ex) where TException : Exception { }
+
+        public static void ExtensionMethod<T>(this T instance, Exception ex) where T : ExtensionClass { }
+    }
+}

--- a/TestCases/GenericMethodTest.cs
+++ b/TestCases/GenericMethodTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using LitJson;
 using ILRuntimeTest.TestFramework;
+using ILRuntimeTest.TestBase;
 
 namespace TestCases
 {
@@ -316,5 +317,13 @@ namespace TestCases
         {
             func(a[0]);
         }
+
+        public static void GenericExtensionMethodTest()
+        {
+            var ec = new ExtensionClass();
+            ec.ExtensionMethod(null);
+        }
     }
+
+
 }


### PR DESCRIPTION
添加一个泛型扩展方法的测试用例，目前这个测试用例无法通过！
原因是获取CLRType.GetMethod中筛选泛型方法还待完善。

Co-Authored-By: Clay Zhang <clayzx@msn.com>