### PR TITLE
修复ILRuntimeParameterInfo.cs中Name属性丢失的问题 & IsInstanceOfType的无法判断内部类型的异常

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
@@ -24,5 +24,13 @@ namespace ILRuntime.Reflection
                 return type.ReflectionType;
             }
         }
+
+        public override string Name
+        {
+            get
+            {
+                return type.FullName;
+            }
+        }
     }
 }

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -252,7 +252,13 @@ namespace ILRuntime.Reflection
 
         public override bool IsInstanceOfType(object o)
         {
-            return o != null && IsAssignableFrom(o.GetType());
+            if (o == null)
+            {
+                return false;
+            }
+
+            var instance = o as ILTypeInstance;
+            return IsAssignableFrom(instance != null ? instance.Type.ReflectionType : o.GetType());
         }
 
         public override Type GetElementType()

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -250,6 +250,11 @@ namespace ILRuntime.Reflection
             return type.CanAssignTo(ILType);
         }
 
+        public override bool IsInstanceOfType(object o)
+        {
+            return o != null && IsAssignableFrom(o.GetType());
+        }
+
         public override Type GetElementType()
         {
             if (type.IsArray)

--- a/ILRuntime/Reflection/ILRuntimeWrapperType.cs
+++ b/ILRuntime/Reflection/ILRuntimeWrapperType.cs
@@ -180,6 +180,12 @@ namespace ILRuntime.Reflection
                 c = ((ILRuntimeType)c).ILType.TypeForCLR;
             return et.IsAssignableFrom(c);
         }
+
+        public override bool IsInstanceOfType(object o)
+        {
+            return o != null && IsAssignableFrom(o.GetType());
+        }
+
         public override Type GetNestedType(string name, BindingFlags bindingAttr)
         {
             return et.GetNestedType(name, bindingAttr);

--- a/ILRuntime/Reflection/ILRuntimeWrapperType.cs
+++ b/ILRuntime/Reflection/ILRuntimeWrapperType.cs
@@ -183,7 +183,13 @@ namespace ILRuntime.Reflection
 
         public override bool IsInstanceOfType(object o)
         {
-            return o != null && IsAssignableFrom(o.GetType());
+            if (o == null)
+            {
+                return false;
+            }
+
+            var instance = o as ILTypeInstance;
+            return IsAssignableFrom(instance != null ? instance.Type.ReflectionType : o.GetType());
         }
 
         public override Type GetNestedType(string name, BindingFlags bindingAttr)


### PR DESCRIPTION
- 修复ILRuntimeParameterInfo.cs中Name属性丢失的问题(#238 )
- 修复修复IsInstanceOfType无法判断ILRT内部类型的bug(#240 )

微软的ParameterInfo的Name是全名，所以我这里给了`FullName`