### PR TITLE
Update Extensions.cs

### DIFF
--- a/ILRuntime/Runtime/Extensions.cs
+++ b/ILRuntime/Runtime/Extensions.cs
@@ -273,6 +273,10 @@ namespace ILRuntime.Runtime
             if (param.Length == parameters.Length)
             {
                 var args = m.GetGenericArguments();
+                if (args.Length != genericArguments.Length)
+                {
+                    return false;
+                }
                 if (args.MatchGenericParameters(m.ReturnType, returnType, genericArguments))
                 {
                     for (int i = 0; i < param.Length; i++)


### PR DESCRIPTION
avoid the exception about generic method that same method name and different lenght of generic arguments.