### PR TITLE
在protobuf的应用中使用ProtoBuf.X a = new ProtoBuf.X()无法成功，而使用global::ProtoBu…

### DIFF
--- a/ILRuntime/CLR/TypeSystem/ILType.cs
+++ b/ILRuntime/CLR/TypeSystem/ILType.cs
@@ -732,6 +732,17 @@ namespace ILRuntime.CLR.TypeSystem
                 }
                 else
                     m = GetMethod(string.Format("{0}.{1}", method.DeclearingType.FullName, method.Name), method.Parameters, genericArguments, method.ReturnType, true);
+
+                if (m == null)
+                {
+                    if (method.DeclearingType is ILType)
+                    {
+                        ILType iltype = (ILType)method.DeclearingType;
+                        m = GetMethod(string.Format("global::{0}.{1}", iltype.fullNameForNested, method.Name), method.Parameters, genericArguments, method.ReturnType, true);
+                    }
+                    else
+                        m = GetMethod(string.Format("global::{0}.{1}", method.DeclearingType.FullName, method.Name), method.Parameters, genericArguments, method.ReturnType, true);
+                }
             }
 
             if (m == null)


### PR DESCRIPTION
在protobuf的应用中使用ProtoBuf.X a = new ProtoBuf.X()无法成功，而使用global::ProtoBuf.X就可以