### PR TITLE
use equal instead of == in ILRuntime/Reflection/ILRuntimeMethodInfo.cs

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -123,7 +123,7 @@ namespace ILRuntime.Reflection
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i] == attributeType)
+                if (attributeTypes[i].Equals(attributeType))
                     res.Add(customAttributes[i]);
             }
             return res.ToArray();


### PR DESCRIPTION
in ILRuntime/Reflection/ILRuntimeMethodInfo.cs : GetCustomAttributes

```
    for (int i = 0; i < customAttributes.Length; i++)
    {
        if (attributeTypes[i].Equals(attributeType))
            res.Add(customAttributes[i]);
    }

```
use Equals instead of == 