### PR TITLE
Fixed: 修复AppDomain在更近类型名称返回类型解析时，对二维或者多维数组都当做一维数组来处理的bug

### DIFF
--- a/ILRuntime/CLR/Utils/Extensions.cs
+++ b/ILRuntime/CLR/Utils/Extensions.cs
@@ -96,7 +96,8 @@ namespace ILRuntime.CLR.Utils
             StringBuilder sb = new StringBuilder();
             List<string> ga;
             bool isArray;
-            Runtime.Enviorment.AppDomain.ParseGenericType(typename, out baseType, out ga, out isArray);
+            byte rank;
+            Runtime.Enviorment.AppDomain.ParseGenericType(typename, out baseType, out ga, out isArray, out rank);
             string baseTypeQualification = null;
             bool hasGA = ga != null && ga.Count > 0;
             if (baseType == argumentName)
@@ -143,7 +144,12 @@ namespace ILRuntime.CLR.Utils
                 sb.Append(']');
             }
             if (isArray)
-                sb.Append("[]");
+            {
+                sb.Append("[");
+                for (int i = 0; i < rank - 1; i++)
+                    sb.Append(",");
+                sb.Append("]");
+            }
             return sb.ToString();
         }
 

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -534,8 +534,8 @@ namespace ILRuntime.Runtime.Enviorment
             string baseType;
             List<string> genericParams;
             bool isArray;
-
-            ParseGenericType(fullname, out baseType, out genericParams, out isArray);
+            byte rank;
+            ParseGenericType(fullname, out baseType, out genericParams, out isArray, out rank);
 
 
             bool isByRef = baseType.EndsWith("&");
@@ -557,7 +557,7 @@ namespace ILRuntime.Runtime.Enviorment
                     for (int i = 0; i < genericArguments.Length; i++)
                     {
                         string key = null;
-                        if(bt is ILType ilt)
+                        if (bt is ILType ilt)
                         {
                             key = ilt.TypeDefinition.GenericParameters[i].FullName;
                         }
@@ -586,7 +586,7 @@ namespace ILRuntime.Runtime.Enviorment
                             /*if (genericParams[i].Contains(","))
                                 sb.Append(genericParams[i].Substring(0, genericParams[i].IndexOf(',')));
                             else*/
-                                sb.Append(genericParams[i]);
+                            sb.Append(genericParams[i]);
                         }
                         sb.Append('>');
                         var asmName = sb.ToString();
@@ -597,7 +597,7 @@ namespace ILRuntime.Runtime.Enviorment
 
                 if (isArray)
                 {
-                    bt = bt.MakeArrayType(1);
+                    bt = bt.MakeArrayType(rank);
                     if (bt is CLRType)
                         clrTypeMapping[bt.TypeForCLR] = bt;
                     mapType[bt.FullName] = bt;
@@ -645,15 +645,17 @@ namespace ILRuntime.Runtime.Enviorment
             return null;
         }
 
-        internal static void ParseGenericType(string fullname, out string baseType, out List<string> genericParams, out bool isArray)
+        internal static void ParseGenericType(string fullname, out string baseType, out List<string> genericParams, out bool isArray, out byte rank)
         {
             StringBuilder sb = new StringBuilder();
             int depth = 0;
+            rank = 0;
             baseType = "";
             genericParams = null;
             if (fullname.Length > 2 && fullname.Substring(fullname.Length - 2) == "[]")
             {
                 fullname = fullname.Substring(0, fullname.Length - 2);
+                rank = 1;
                 isArray = true;
             }
             else
@@ -680,6 +682,8 @@ namespace ILRuntime.Runtime.Enviorment
                             name = name.Substring(1, name.Length - 2);
                         if (!string.IsNullOrEmpty(name))
                             genericParams.Add(name);
+                        else
+                            ++rank;
                         sb.Length = 0;
                         continue;
                     }
@@ -698,6 +702,7 @@ namespace ILRuntime.Runtime.Enviorment
                                 if (!isArray)
                                 {
                                     isArray = true;
+                                    ++rank;
                                 }
                                 else
                                 {


### PR DESCRIPTION
测试用例：
AppDomain domain = new AppDomain();
var result = domain.GetType(typeof(byte[,]));


未修复前result为 :   System.Byte[]

正确结果应为 :  System.Byte[,]