### PR TITLE
修复jsondata直接反向tostring时不处理空object值的问题

### DIFF
--- a/LitJson/JsonData.cs
+++ b/LitJson/JsonData.cs
@@ -741,6 +741,10 @@ namespace LitJson
 
         private static void WriteJson (IJsonWrapper obj, JsonWriter writer)
         {
+            if(obj is JsonData && (obj as JsonData).type == JsonType.None)
+            {
+                (obj as JsonData).EnsureDictionary();
+            }
             if (obj == null) {
                 writer.Write (null);
                 return;


### PR DESCRIPTION
字符串to jsondata，再立即tostring，空对象只写key不写大括号