### PR TITLE
Update ILRuntimeMethodInfo.cs

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -166,7 +166,7 @@ namespace ILRuntime.Reflection
         {
             get
             {
-                return method.ReturnType.ReflectionType;
+                return method.ReturnType?.ReflectionType;
             }
         }
     }


### PR DESCRIPTION
修复泛型方法获取不到ReturnType时会发生的空引用错误