### PR TITLE
CLRBindings.InitializeSmart实现

### DIFF
--- a/ILRuntime/ILRuntime.csproj
+++ b/ILRuntime/ILRuntime.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Reflection\ILRuntimeType.cs" />
     <Compile Include="Runtime\Adaptors\CLRCrossBindingAdaptors.cs" />
     <Compile Include="Runtime\CLRBinding\BindingGeneratorExtensions.cs" />
+    <Compile Include="Runtime\CLRBinding\CLRBindings.cs" />
     <Compile Include="Runtime\CLRBinding\CommonBindingGenerator.cs" />
     <Compile Include="Runtime\CLRBinding\ValueTypeBindingGenerator.cs" />
     <Compile Include="Runtime\CLRBinding\FieldBindingGenerator.cs" />

--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -323,8 +323,14 @@ using System.Reflection;
 
 namespace ILRuntime.Runtime.Generated
 {
-    class CLRBindings
+    partial class CLRBindings
     {
+
+        static CLRBindings()
+        {
+            InitializeAction = Initialize;
+        }
+
         /// <summary>
         /// Initialize the CLR binding, please invoke this AFTER CLR Redirection registration
         /// </summary>
@@ -739,8 +745,14 @@ using System.Reflection;
 
 namespace ILRuntime.Runtime.Generated
 {
-    class CLRBindings
-    {");
+    partial class CLRBindings
+    {
+
+        static CLRBindings()
+        {
+            InitializeAction = Initialize;
+        }
+");
 
                 if (valueTypeBinders != null)
                 {

--- a/ILRuntime/Runtime/CLRBinding/CLRBindings.cs
+++ b/ILRuntime/Runtime/CLRBinding/CLRBindings.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace ILRuntime.Runtime.Generated
+{
+    partial class CLRBindings
+    {
+
+        static private Action<ILRuntime.Runtime.Enviorment.AppDomain> InitializeAction;
+        static public void InitializeSmart(ILRuntime.Runtime.Enviorment.AppDomain app)
+        {
+            if (InitializeAction != null)
+            {
+                //Debug.Log("CLRBindings.InitializeAction is set, run InitializeAction");
+                InitializeAction(app);
+            }
+            else
+            {
+                //Debug.Log("CLRBindings.InitializeAction is null, skip InitializeAction");
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
利用partial和在类的静态构造函数中注入InitializeAction委托来实现CLRBindings生成的代码存在与否都不用更改调用代码，原本CLRBindings.Initialize的调用处改为CLRBindings.InitializeSmart后，不管是否生成绑定代码都不会有编译错误

原本想直接用分步方法的，但是考虑到分布方法只能private，无法兼容已经有的大量调用，改为委托方式