### PR TITLE
修复协程函数执行 #301 #332

### DIFF
--- a/ILRuntime/CLR/Method/CLRMethod.cs
+++ b/ILRuntime/CLR/Method/CLRMethod.cs
@@ -314,7 +314,13 @@ namespace ILRuntime.CLR.Method
                     if (declaringType.IsValueType)
                         instance = ILIntepreter.CheckAndCloneValueType(instance, appdomain);
                     if (instance == null)
+                    {
+                        // 对于 System.Nullable<T> 和 null 判断时, 会调用 get_HasValue 方法
+                        // 这里, 可能是设计问题, 当该变量未赋值时, instance 为 null
+                        // 因此, 作为临时修复, 当 instance 为 null, 则直接返回 false
+                        if (declaringType.IsValueType && this.Name == "get_HasValue") return false;
                         throw new NullReferenceException();
+                    }
                 }
                 object res = null;
                 /*if (redirect != null)

--- a/ILRuntime/CLR/Method/CLRMethod.cs
+++ b/ILRuntime/CLR/Method/CLRMethod.cs
@@ -247,6 +247,12 @@ namespace ILRuntime.CLR.Method
             return (StackObject*)((long)a - sizeof(StackObject) * b);
         }
 
+        void ClearInvokeParams()
+        {
+            var arr = invocationParam;
+            for (int i = 0; i < arr.Length; i++) arr[i] = null;
+        }
+
         public unsafe object Invoke(Runtime.Intepreter.ILIntepreter intepreter, StackObject* esp, IList<object> mStack, bool isNewObj = false)
         {
             if (parameters == null)
@@ -278,6 +284,7 @@ namespace ILRuntime.CLR.Method
                         if (instance is CrossBindingAdaptorType && paramCount == 0)//It makes no sense to call the Adaptor's default constructor
                             return null;
                         cDef.Invoke(instance, param);
+                        ClearInvokeParams();
                         return null;
                     }
                     else
@@ -290,6 +297,7 @@ namespace ILRuntime.CLR.Method
                     var res = cDef.Invoke(param);
 
                     FixReference(paramCount, esp, param, mStack, null, false);
+                    ClearInvokeParams();
                     return res;
                 }
 
@@ -317,6 +325,7 @@ namespace ILRuntime.CLR.Method
                 }
 
                 FixReference(paramCount, esp, param, mStack, instance, !def.IsStatic);
+                ClearInvokeParams();
                 return res;
             }
         }

--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -190,7 +190,7 @@ namespace ILRuntime.CLR.Method
             return null;
         }
 
-        internal OpCode[] Body
+        public OpCode[] Body
         {
             get
             {

--- a/ILRuntime/CLR/Utils/Extensions.cs
+++ b/ILRuntime/CLR/Utils/Extensions.cs
@@ -276,9 +276,10 @@ namespace ILRuntime.CLR.Utils
             }
             else if (obj is ILTypeInstance)
             {
-                var adapter = obj as IDelegateAdapter;
+                if (pt == typeof(ILTypeInstance)) return obj;
 
-                if (adapter != null && pt != typeof(ILTypeInstance))
+                var adapter = obj as IDelegateAdapter;
+                if (adapter != null)
                 {
                     return adapter.Delegate;
                 }

--- a/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingCodeGenerator.cs
@@ -349,7 +349,7 @@ namespace ILRuntime.Runtime.Generated
             GenerateBindingInitializeScript(clsNames, valueTypeBinders, outputPath);
         }
 
-        static void PrewarmDomain(ILRuntime.Runtime.Enviorment.AppDomain domain)
+        public static void PrewarmDomain(ILRuntime.Runtime.Enviorment.AppDomain domain)
         {
             var arr = domain.LoadedTypes.Values.ToArray();
             //Prewarm

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1438,5 +1438,32 @@ namespace ILRuntime.Runtime.Enviorment
             detail.Sort((a, b) => b.TotalSize - a.TotalSize);
             return size;
         }
+
+        [System.Diagnostics.Conditional("ENABLE_PROFILER")]
+        public void BeginSample(string name)
+        {
+#if DEBUG && !NO_PROFILER
+            if (System.Threading.Thread.CurrentThread.ManagedThreadId == UnityMainThreadID)
+#if UNITY_5_5_OR_NEWER
+                UnityEngine.Profiling.Profiler.BeginSample(name);
+#else
+                UnityEngine.Profiler.BeginSample(name);
+#endif
+#endif
+        }
+
+        [System.Diagnostics.Conditional("ENABLE_PROFILER")]
+        public void EndSample()
+        {
+#if DEBUG && !NO_PROFILER
+            if (System.Threading.Thread.CurrentThread.ManagedThreadId == UnityMainThreadID)
+#if UNITY_5_5_OR_NEWER
+                UnityEngine.Profiling.Profiler.EndSample();
+#else
+                UnityEngine.Profiler.EndSample();
+#endif
+#endif
+        }
+
     }
 }

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -73,7 +73,7 @@ namespace ILRuntime.Runtime.Enviorment
             return UnityMainThreadID != 0 && (UnityMainThreadID != System.Threading.Thread.CurrentThread.ManagedThreadId);
         }
 #endif
-        internal bool SuppressStaticConstructor { get; set; }
+        public bool SuppressStaticConstructor { get; set; }
 
         public unsafe AppDomain()
         {
@@ -1295,7 +1295,7 @@ namespace ILRuntime.Runtime.Enviorment
             return method;
         }
 
-        internal IMethod GetMethod(int tokenHash)
+        public IMethod GetMethod(int tokenHash)
         {
             IMethod res;
             if (mapMethod.TryGetValue(tokenHash, out res))

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -80,6 +80,7 @@ namespace ILRuntime.Runtime.Intepreter
         }
         public object Run(ILMethod method, object instance, object[] p)
         {
+            AppDomain.BeginSample("ILRuntime.ILIntepreter.Run");
             IList<object> mStack = stack.ManagedStack;
             int mStackBase = mStack.Count;
             StackObject* esp = stack.StackBase;
@@ -102,6 +103,7 @@ namespace ILRuntime.Runtime.Intepreter
 #else
             ((UncheckedList<object>)mStack).RemoveRange(mStackBase, mStack.Count - mStackBase);
 #endif
+            AppDomain.EndSample();
             return result;
         }
         internal StackObject* Execute(ILMethod method, StackObject* esp, out bool unhandledException)
@@ -110,16 +112,7 @@ namespace ILRuntime.Runtime.Intepreter
             if (method == null)
                 throw new NullReferenceException();
 #endif
-#if DEBUG && !NO_PROFILER
-            if (System.Threading.Thread.CurrentThread.ManagedThreadId == AppDomain.UnityMainThreadID)
-
-#if UNITY_5_5_OR_NEWER
-                UnityEngine.Profiling.Profiler.BeginSample(method.ToString());
-#else
-                UnityEngine.Profiler.BeginSample(method.ToString());
-#endif
-
-#endif
+            AppDomain.BeginSample(method.ToString());
             OpCode[] body = method.Body;
             StackFrame frame;
             stack.InitializeFrame(method, esp, out frame);
@@ -1828,25 +1821,9 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (!allowUnboundCLRMethod)
                                                         throw new NotSupportedException(cm.ToString() + " is not bound!");
 #endif
-#if DEBUG && !NO_PROFILER
-                                                    if (System.Threading.Thread.CurrentThread.ManagedThreadId == AppDomain.UnityMainThreadID)
-
-#if UNITY_5_5_OR_NEWER
-                                                        UnityEngine.Profiling.Profiler.BeginSample(cm.ToString());
-#else
-                                                        UnityEngine.Profiler.BeginSample(cm.ToString());
-#endif
-#endif
+                                                    AppDomain.BeginSample(cm.ToString());
                                                     object result = cm.Invoke(this, esp, mStack);
-#if DEBUG && !NO_PROFILER
-                                                    if (System.Threading.Thread.CurrentThread.ManagedThreadId == AppDomain.UnityMainThreadID)
-#if UNITY_5_5_OR_NEWER
-                                                        UnityEngine.Profiling.Profiler.EndSample();
-#else
-                                                        UnityEngine.Profiler.EndSample();
-#endif
-
-#endif
+                                                    AppDomain.EndSample();
                                                     if (result is CrossBindingAdaptorType)
                                                         result = ((CrossBindingAdaptorType)result).ILInstance;
                                                     int paramCount = cm.ParameterCount;
@@ -4259,14 +4236,7 @@ namespace ILRuntime.Runtime.Intepreter
                     }
                 }
             }
-#if DEBUG && !NO_PROFILER
-            if (System.Threading.Thread.CurrentThread.ManagedThreadId == AppDomain.UnityMainThreadID)
-#if UNITY_5_5_OR_NEWER
-                UnityEngine.Profiling.Profiler.EndSample();
-#else
-                UnityEngine.Profiler.EndSample();
-#endif
-#endif
+            AppDomain.EndSample();
             //ClearStack
             return stack.PopFrame(ref frame, esp);
         }

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -1821,9 +1821,9 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (!allowUnboundCLRMethod)
                                                         throw new NotSupportedException(cm.ToString() + " is not bound!");
 #endif
-                                                    AppDomain.BeginSample(cm.ToString());
+                                                    //AppDomain.BeginSample(cm.ToString()); // error: "Missing Profiler.EndSample (BeginSample and EndSample count must match)"
                                                     object result = cm.Invoke(this, esp, mStack);
-                                                    AppDomain.EndSample();
+                                                    //AppDomain.EndSample();
                                                     if (result is CrossBindingAdaptorType)
                                                         result = ((CrossBindingAdaptorType)result).ILInstance;
                                                     int paramCount = cm.ParameterCount;

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -1726,7 +1726,8 @@ namespace ILRuntime.Runtime.Intepreter
 
                                         int addr = ip->TokenInteger;
                                         var sql = from e in method.ExceptionHandler
-                                                  where addr == e.HandlerEnd + 1 && e.HandlerType == ExceptionHandlerType.Finally || e.HandlerType == ExceptionHandlerType.Fault
+                                                  //where addr == e.HandlerEnd + 1 && e.HandlerType == ExceptionHandlerType.Finally || e.HandlerType == ExceptionHandlerType.Fault
+                                                  where addr == e.HandlerEnd + 1 && e.HandlerType == ExceptionHandlerType.Finally   // 如果调用 Fault 会导致协程函数 只执行一次
                                                   select e;
                                         eh = sql.FirstOrDefault();
                                         if (eh != null)

--- a/ILRuntime/Runtime/Intepreter/OpCodes/OpCode.cs
+++ b/ILRuntime/Runtime/Intepreter/OpCodes/OpCode.cs
@@ -7,11 +7,11 @@ using ILRuntime.CLR.Method;
 
 namespace ILRuntime.Runtime.Intepreter.OpCodes
 {
-  
+
     /// <summary>
     /// IL指令
     /// </summary>
-    struct OpCode
+    public struct OpCode
     {
         /// <summary>
         /// 当前指令

--- a/ILRuntime/Runtime/Intepreter/OpCodes/OpCodeEnum.cs
+++ b/ILRuntime/Runtime/Intepreter/OpCodes/OpCodeEnum.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace ILRuntime.Runtime.Intepreter.OpCodes
 {
-    enum OpCodeEnum
+    public enum OpCodeEnum
     {
         /// <summary>
         /// 如果修补操作码，则填充空间。尽管可能消耗处理周期，但未执行任何有意义的操作。


### PR DESCRIPTION
我不确定是否会引起其它问题， 但该修改可以解决协程无法正常执行的问题。

在协程函数中， 例如：
static IEnumerator func1()
{
         foreach (var x in GetDatas())
        {
              yield return null;    // 此处会生成 leave.s 指令,  之前的解析器中会执行 Fault 代码， 导致提前执行该协程的析构函数， 破坏了协程的执行

