### PR TITLE
Improve performance for JsonIgnore

### DIFF
--- a/LitJson/JsonMapper.cs
+++ b/LitJson/JsonMapper.cs
@@ -238,10 +238,8 @@ namespace LitJson
 
             data.Properties = new Dictionary<string, PropertyMetadata> ();
             foreach (PropertyInfo p_info in type.GetProperties ()) {
-                if (p_info.GetCustomAttribute(typeof(JsonIgnoreAttribute), true) != null)
-                {
+                if (Attribute.IsDefined(p_info, typeof(JsonIgnoreAttribute), true))
                     continue;
-                }
                 if (p_info.Name == "Item") {
                     ParameterInfo[] parameters = p_info.GetIndexParameters ();
 
@@ -269,10 +267,8 @@ namespace LitJson
             }
 
             foreach (FieldInfo f_info in type.GetFields ()) {
-                if (f_info.GetCustomAttribute(typeof(JsonIgnoreAttribute), true) != null)
-                {
+                if (Attribute.IsDefined(f_info, typeof(JsonIgnoreAttribute), true))
                     continue;
-                }
                 PropertyMetadata p_data = new PropertyMetadata ();
                 p_data.Info = f_info;
                 p_data.IsField = true;
@@ -298,10 +294,8 @@ namespace LitJson
             IList<PropertyMetadata> props = new List<PropertyMetadata> ();
 
             foreach (PropertyInfo p_info in type.GetProperties ()) {
-                if (p_info.GetCustomAttribute(typeof(JsonIgnoreAttribute), true) != null)
-                {
+                if (Attribute.IsDefined(p_info, typeof(JsonIgnoreAttribute), true))
                     continue;
-                }
 
                 if (p_info.Name == "Item")
                     continue;
@@ -313,10 +307,8 @@ namespace LitJson
             }
 
             foreach (FieldInfo f_info in type.GetFields ()) {
-                if (f_info.GetCustomAttribute(typeof(JsonIgnoreAttribute), true) != null)
-                {
+                if (Attribute.IsDefined(f_info, typeof(JsonIgnoreAttribute), true))
                     continue;
-                }
 
                 PropertyMetadata p_data = new PropertyMetadata ();
                 p_data.Info = f_info;


### PR DESCRIPTION
经测试发现MemberInfo的GetCustomAttribute方法实际会创建对应的Attribute对象返回，多次调用则多次创建，改用IsDefined来优化性能

![111](https://user-images.githubusercontent.com/11712968/109777506-c4698b80-7c3e-11eb-8c51-5f8b94e42ada.png)
