### PR TITLE
修复调用扩展方法System.Reflection.CustomAttributeExtensions.GetCustomAttribute无法获取自定义Attribute的问题

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
@@ -26,7 +26,7 @@ namespace ILRuntime.Reflection
         string name;
         FieldDefinition definition;
         Runtime.Enviorment.AppDomain appdomain;
-        object[] customAttributes;
+        Attribute[] customAttributes;
         Type[] attributeTypes;
 
         public IType ILFieldType { get { return fieldType; } }
@@ -73,7 +73,7 @@ namespace ILRuntime.Reflection
 
         void InitializeCustomAttribute()
         {
-            customAttributes = new object[definition.CustomAttributes.Count];
+            customAttributes = new Attribute[definition.CustomAttributes.Count];
             attributeTypes = new Type[customAttributes.Length];
             for (int i = 0; i < definition.CustomAttributes.Count; i++)
             {
@@ -81,7 +81,7 @@ namespace ILRuntime.Reflection
                 var at = appdomain.GetType(attribute.AttributeType, null, null);
                 try
                 {
-                    object ins = attribute.CreateInstance(at, appdomain);
+                    Attribute ins = attribute.CreateInstance(at, appdomain) as Attribute;
 
                     attributeTypes[i] = at.ReflectionType;
                     customAttributes[i] = ins;

--- a/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
@@ -17,7 +17,7 @@ namespace ILRuntime.Reflection
         Mono.Cecil.PropertyDefinition definition;
         ILRuntime.Runtime.Enviorment.AppDomain appdomain;
 
-        object[] customAttributes;
+        Attribute[] customAttributes;
         Type[] attributeTypes;
 
         public ILMethod Getter
@@ -68,7 +68,7 @@ namespace ILRuntime.Reflection
 
         void InitializeCustomAttribute()
         {
-            customAttributes = new object[definition.CustomAttributes.Count];
+            customAttributes = new Attribute[definition.CustomAttributes.Count];
             attributeTypes = new Type[customAttributes.Length];
             for (int i = 0; i < definition.CustomAttributes.Count; i++)
             {
@@ -76,7 +76,7 @@ namespace ILRuntime.Reflection
                 var at = appdomain.GetType(attribute.AttributeType, null, null);
                 try
                 {
-                    object ins = attribute.CreateInstance(at, appdomain);
+                    Attribute ins = attribute.CreateInstance(at, appdomain) as Attribute;
 
                     attributeTypes[i] = at.ReflectionType;
                     customAttributes[i] = ins;

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -14,7 +14,7 @@ namespace ILRuntime.Reflection
     {
         ILType type;
         Runtime.Enviorment.AppDomain appdomain;
-        object[] customAttributes;
+        Attribute[] customAttributes;
         Type[] attributeTypes;
         ILRuntimeFieldInfo[] fields;
         ILRuntimePropertyInfo[] properties;
@@ -32,11 +32,11 @@ namespace ILRuntime.Reflection
         {
             if(type.TypeDefinition == null)
             {
-                customAttributes = new object[0];
+                customAttributes = new Attribute[0];
                 attributeTypes = new Type[0];
                 return;
             }
-            customAttributes = new object[type.TypeDefinition.CustomAttributes.Count];
+            customAttributes = new Attribute[type.TypeDefinition.CustomAttributes.Count];
             attributeTypes = new Type[customAttributes.Length];
             for (int i = 0; i < type.TypeDefinition.CustomAttributes.Count; i++)
             {
@@ -44,7 +44,7 @@ namespace ILRuntime.Reflection
                 var at = appdomain.GetType(attribute.AttributeType, type, null);
                 try
                 {
-                    object ins = attribute.CreateInstance(at, appdomain);
+                    Attribute ins = attribute.CreateInstance(at, appdomain) as Attribute;
 
                     attributeTypes[i] = at.ReflectionType is ILRuntimeWrapperType ? at.TypeForCLR : at.ReflectionType;
                     customAttributes[i] = ins;


### PR DESCRIPTION
对ILRuntimeFieldInfo、ILRuntimePropertyInfo、ILRuntimeType对象调用扩展方法System.Reflection.CustomAttributeExtensions.GetCustomAttribute无法获取自定义Attribute。
下图中的红框部分为该扩展方法最终调用到的地方
![9EABC771-C837-4733-B8C4-3B06BAC2540D](https://user-images.githubusercontent.com/4771484/109922276-0b678780-7cf8-11eb-810c-835df9f0978d.png)
强制转换失败的原因在于重写方法GetCustomAttributes的返回值object[]无法强制转换为Attribute[]。
将代码中的字段customAttributes的类型由object[]改为Attribute[]可解决这个问题