### PR TITLE
递归prewarm

### DIFF
--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -264,17 +264,13 @@ namespace ILRuntime.CLR.Method
             private set;
         }
 
-        public void Prewarm(HashSet<ILMethod> alreadyPrewarmed)
+        public void Prewarm()
         {
-            //如果参数alreadyPrewarmed不为空，则以递归方式prewarm当前方法，以及所有子调用
-            //如果参数alreadyPrewarmed为空，则只prewarm当前方法
-            if (alreadyPrewarmed != null && alreadyPrewarmed.Add(this) == false)
-                return;
             if (body == null)
-                InitCodeBody(alreadyPrewarmed);
+                InitCodeBody();
         }
 
-        void InitCodeBody(HashSet<ILMethod> alreadyPrewarmed = null)
+        void InitCodeBody()
         {
             if (def.HasBody)
             {
@@ -292,7 +288,7 @@ namespace ILRuntime.CLR.Method
                 for (int i = 0; i < body.Length; i++)
                 {
                     var c = def.Body.Instructions[i];
-                    InitToken(ref body[i], c.Operand, addr, alreadyPrewarmed);
+                    InitToken(ref body[i], c.Operand, addr);
                     if (i > 0 && c.OpCode.Code == Mono.Cecil.Cil.Code.Callvirt && def.Body.Instructions[i - 1].OpCode.Code == Mono.Cecil.Cil.Code.Constrained)
                     {
                         body[i - 1].TokenLong = body[i].TokenInteger;
@@ -335,7 +331,7 @@ namespace ILRuntime.CLR.Method
                 body = new OpCode[0];
         }
 
-        unsafe void InitToken(ref OpCode code, object token, Dictionary<Mono.Cecil.Cil.Instruction, int> addr, HashSet<ILMethod> alreadyPrewarmed)
+        unsafe void InitToken(ref OpCode code, object token, Dictionary<Mono.Cecil.Cil.Instruction, int> addr)
         {
             switch (code.Code)
             {
@@ -435,11 +431,6 @@ namespace ILRuntime.CLR.Method
                                 code.TokenInteger = m.GetHashCode();
                             else
                                 code.TokenInteger = token.GetHashCode();
-                            //递归prewarm
-                            if (alreadyPrewarmed != null && m is ILMethod ilMethod)
-                            {
-                                ilMethod.Prewarm(alreadyPrewarmed);
-                            }
                         }
                         else
                         {

--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -312,13 +312,20 @@ namespace ILRuntime.CLR.Method
                     case OpCodeEnum.Ldvirtftn:
                     case OpCodeEnum.Callvirt:
                         {
-                            //如果参数alreadyPrewarmed不为空，则不仅prewarm当前方法，还会递归prewarm所有子调用
-                            //如果参数alreadyPrewarmed为空，则只prewarm当前方法
-                            if (alreadyPrewarmed == null)
-                                continue;
-                            var ilm = appdomain.GetMethod(ins.TokenInteger) as ILMethod;
-                            if (ilm != null)
-                                ilm.Prewarm(alreadyPrewarmed);
+                            var m = appdomain.GetMethod(ins.TokenInteger);
+                            if (m is ILMethod ilm)
+                            {
+                                //如果参数alreadyPrewarmed不为空，则不仅prewarm当前方法，还会递归prewarm所有子调用
+                                //如果参数alreadyPrewarmed为空，则只prewarm当前方法
+                                if (alreadyPrewarmed != null)
+                                {
+                                    ilm.Prewarm(alreadyPrewarmed);
+                                }
+                            }
+                            else if (m is CLRMethod clrm)
+                            {
+                                ILRuntime.CLR.Utils.Extensions.GetTypeFlags(clrm.DeclearingType.TypeForCLR);
+                            }
                         }
                         break;
                     case OpCodeEnum.Ldfld:

--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -282,7 +282,7 @@ namespace ILRuntime.CLR.Method
                 return;
             //当前方法用到的IType，提前InitializeMethods()。各个子调用，提前InitParameters()
             var body = Body;
-            //当前方法用到的CLR局部变量，提前InitializeFields()
+            //当前方法用到的CLR局部变量，提前InitializeFields()、GetTypeFlags()
             for (int i = 0; i < LocalVariableCount; i++)
             {
                 var v = Variables[i];
@@ -299,6 +299,7 @@ namespace ILRuntime.CLR.Method
                 if (t is CLRType ct)
                 {
                     var fields = ct.Fields;
+                    ILRuntime.CLR.Utils.Extensions.GetTypeFlags(ct.TypeForCLR);
                 }
             }
             foreach (var ins in body)

--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -264,10 +264,80 @@ namespace ILRuntime.CLR.Method
             private set;
         }
 
-        public void Prewarm()
+        public void Prewarm(bool recursive)
         {
-            if (body == null)
-                InitCodeBody();
+            HashSet<ILMethod> alreadyPrewarmed = null;
+            if (recursive)
+            {
+                alreadyPrewarmed = new HashSet<ILMethod>();
+            }
+            Prewarm(alreadyPrewarmed);
+        }
+
+        private void Prewarm(HashSet<ILMethod> alreadyPrewarmed)
+        {
+            if (alreadyPrewarmed != null && alreadyPrewarmed.Add(this) == false)
+                return;
+            if (GenericParameterCount > 0 && !IsGenericInstance)
+                return;
+            //当前方法用到的IType，提前InitializeMethods()。各个子调用，提前InitParameters()
+            var body = Body;
+            //当前方法用到的CLR局部变量，提前InitializeFields()
+            for (int i = 0; i < LocalVariableCount; i++)
+            {
+                var v = Variables[i];
+                var vt = v.VariableType;
+                IType t;
+                if (vt.IsGenericParameter)
+                {
+                    t = FindGenericArgument(vt.Name);
+                }
+                else
+                {
+                    t = appdomain.GetType(v.VariableType, DeclearingType, this);
+                }
+                if (t is CLRType ct)
+                {
+                    var fields = ct.Fields;
+                }
+            }
+            foreach (var ins in body)
+            {
+                switch (ins.Code)
+                {
+                    case OpCodeEnum.Call:
+                    case OpCodeEnum.Newobj:
+                    case OpCodeEnum.Ldftn:
+                    case OpCodeEnum.Ldvirtftn:
+                    case OpCodeEnum.Callvirt:
+                        {
+                            //如果参数alreadyPrewarmed不为空，则不仅prewarm当前方法，还会递归prewarm所有子调用
+                            //如果参数alreadyPrewarmed为空，则只prewarm当前方法
+                            if (alreadyPrewarmed == null)
+                                continue;
+                            var ilm = appdomain.GetMethod(ins.TokenInteger) as ILMethod;
+                            if (ilm != null)
+                                ilm.Prewarm(alreadyPrewarmed);
+                        }
+                        break;
+                    case OpCodeEnum.Ldfld:
+                    case OpCodeEnum.Stfld:
+                    case OpCodeEnum.Ldflda:
+                    case OpCodeEnum.Ldsfld:
+                    case OpCodeEnum.Ldsflda:
+                    case OpCodeEnum.Stsfld:
+                    case OpCodeEnum.Ldtoken:
+                        {
+                            //提前InitializeBaseType()
+                            var t = appdomain.GetType((int)(ins.TokenLong >> 32));
+                            if (t != null)
+                            {
+                                var baseType = t.BaseType;
+                            }
+                        }
+                        break;
+                }
+            }
         }
 
         void InitCodeBody()

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1008,7 +1008,7 @@ namespace ILRuntime.Runtime.Enviorment
             var methods = t.GetMethods();
             foreach(var i in methods)
             {
-                ((ILMethod)i).Prewarm();
+                ((ILMethod)i).Prewarm(true);
             }
         }
 
@@ -1031,7 +1031,7 @@ namespace ILRuntime.Runtime.Enviorment
                         ILMethod m = (ILMethod)j;
                         if(m.Name == mn && m.GenericParameterCount == 0)
                         {
-                            m.Prewarm();
+                            m.Prewarm(false);
                         }
                     }
                 }

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1005,11 +1005,10 @@ namespace ILRuntime.Runtime.Enviorment
             IType t = GetType(type);
             if (t == null || t is CLRType)
                 return;
-            var alreadyPrewarmed = new HashSet<ILMethod>();
             var methods = t.GetMethods();
             foreach(var i in methods)
             {
-                ((ILMethod)i).Prewarm(alreadyPrewarmed);
+                ((ILMethod)i).Prewarm();
             }
         }
 
@@ -1024,7 +1023,6 @@ namespace ILRuntime.Runtime.Enviorment
                 IType t = GetType(i.TypeName);
                 if (t == null || t is CLRType || i.MethodNames == null)
                     continue;
-                var alreadyPrewarmed = new HashSet<ILMethod>();
                 var methods = t.GetMethods();
                 foreach (var mn in i.MethodNames)
                 {
@@ -1033,7 +1031,7 @@ namespace ILRuntime.Runtime.Enviorment
                         ILMethod m = (ILMethod)j;
                         if(m.Name == mn && m.GenericParameterCount == 0)
                         {
-                            m.Prewarm(alreadyPrewarmed);
+                            m.Prewarm();
                         }
                     }
                 }

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1005,10 +1005,11 @@ namespace ILRuntime.Runtime.Enviorment
             IType t = GetType(type);
             if (t == null || t is CLRType)
                 return;
+            var alreadyPrewarmed = new HashSet<ILMethod>();
             var methods = t.GetMethods();
             foreach(var i in methods)
             {
-                ((ILMethod)i).Prewarm();
+                ((ILMethod)i).Prewarm(alreadyPrewarmed);
             }
         }
 
@@ -1023,6 +1024,7 @@ namespace ILRuntime.Runtime.Enviorment
                 IType t = GetType(i.TypeName);
                 if (t == null || t is CLRType || i.MethodNames == null)
                     continue;
+                var alreadyPrewarmed = new HashSet<ILMethod>();
                 var methods = t.GetMethods();
                 foreach (var mn in i.MethodNames)
                 {
@@ -1031,7 +1033,7 @@ namespace ILRuntime.Runtime.Enviorment
                         ILMethod m = (ILMethod)j;
                         if(m.Name == mn && m.GenericParameterCount == 0)
                         {
-                            m.Prewarm();
+                            m.Prewarm(alreadyPrewarmed);
                         }
                     }
                 }


### PR DESCRIPTION
以递归方式prewarm当前方法，以及所有子调用。提高prewarm的准确性。已知缺陷：遇到CLRMethod（跨域调用）就会打断递归。