### PR TITLE
支持监听ILRuntimeException，以便客户端更准确地上报错误日志

### DIFF
--- a/ILRuntime/Runtime/Debugger/DebugService.cs
+++ b/ILRuntime/Runtime/Debugger/DebugService.cs
@@ -26,6 +26,7 @@ namespace ILRuntime.Runtime.Debugger
         AutoResetEvent evt = new AutoResetEvent(false);
         
         public Action<string> OnBreakPoint;
+        public Action<string> OnILRuntimeException;
 
         public Enviorment.AppDomain AppDomain { get { return domain; } }
 

--- a/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
+++ b/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
@@ -34,12 +34,7 @@ namespace ILRuntime.Runtime.Intepreter
             }
 
             if (ds.OnILRuntimeException != null) {
-                var sb = new StringBuilder();
-                if (innerException != null) {
-                    sb.AppendLine($"{innerException.GetType().Name}: {innerException.Message}");
-                }
-                sb.AppendLine(stackTrace);
-                ds.OnILRuntimeException(sb.ToString());
+                ds.OnILRuntimeException(ToString());
             }
         }
 

--- a/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
+++ b/ILRuntime/Runtime/Intepreter/ILRuntimeException.cs
@@ -32,6 +32,15 @@ namespace ILRuntime.Runtime.Intepreter
                     thisInfo = "";
                 localInfo = ds.GetLocalVariableInfo(intepreter);
             }
+
+            if (ds.OnILRuntimeException != null) {
+                var sb = new StringBuilder();
+                if (innerException != null) {
+                    sb.AppendLine($"{innerException.GetType().Name}: {innerException.Message}");
+                }
+                sb.AppendLine(stackTrace);
+                ds.OnILRuntimeException(sb.ToString());
+            }
         }
 
         public override string StackTrace


### PR DESCRIPTION
由于某些情况下默认的 Error Log 并没有准确包含出错所在位置，因此想通过独立的事件监听获取调用栈信息，以便业务层上报错误日志