### PR TITLE
Remove old about Apple policy

### DIFF
--- a/ReadMe-EN.md
+++ b/ReadMe-EN.md
@@ -20,12 +20,6 @@ Our vision is to create a reliable high performance IL runtime which is also as 
 * Framework for inspecting stack and object information
 * Either Visual Studio integration or Standalone Debugger with GUI.
 
-WARNING!
-========
-Please mainly use this library for bug fixing!! ADDING/HIDING/CHANING features in your APP may violate some platform's guideline(for example iOS), your APP may get REJECTED or even BANNED if you do so.
-
-This libray should not be used for evading Apple's review system, if you do this, it will be on your own risk!
-
 Get Started
 ========
 Unity


### PR DESCRIPTION
Apple policy:
3.3.2 Except as set forth in the next paragraph, an Application may not download or install executable code. Interpreted code may be downloaded to an Application but only so long as such code: (a) does not change the primary purpose of the Application by providing features or functionality that are inconsistent with the intended and advertised purpose of the Application as submitted to the App Store, (b) does not create a store or storefront for other code or applications, and (c) does not bypass signing, sandbox, or other security features of the OS.
