### PR TITLE
Optimized GCAlloc with AppDomain.GetMethod

### DIFF
--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1236,12 +1236,13 @@ namespace ILRuntime.Runtime.Enviorment
             if (token is Mono.Cecil.MethodReference)
             {
                 Mono.Cecil.MethodReference _ref = (token as Mono.Cecil.MethodReference);
-                if (_ref.FullName == "System.Void System.Object::.ctor()")
+                var refFullName = _ref.FullName;
+                if (refFullName == "System.Void System.Object::.ctor()")
                 {
                     mapMethod[hashCode] = null;
                     return null;
                 }
-                if (_ref.FullName == "System.Void System.Attribute::.ctor()")
+                if (refFullName == "System.Void System.Attribute::.ctor()")
                 {
                     mapMethod[hashCode] = null;
                     return null;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40783070/126424115-858981de-dad6-4e51-8f4e-3b84e30b3264.png)

多次调用 MethodReference.FullName， 修改后获取FullName产生的gc可以减少一半
