### PR TITLE
添加Type.IsAssignableFrom方法的重定向，修复非热更类在热更层调用IsAssignableFrom返回值不对的问题

### DIFF
--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -117,6 +117,10 @@ namespace ILRuntime.Runtime.Enviorment
                 {
                     RegisterCLRMethodRedirection(i, CLRRedirections.TypeEquals);
                 }
+                if (i.Name == "IsAssignableFrom" && i.GetParameters()[0].ParameterType == typeof(Type))
+                {
+                    RegisterCLRMethodRedirection(i, CLRRedirections.IsAssignableFrom);
+                }
             }
             foreach (var i in typeof(System.Delegate).GetMethods())
             {

--- a/ILRuntime/Runtime/Enviorment/CLRRedirections.cs
+++ b/ILRuntime/Runtime/Enviorment/CLRRedirections.cs
@@ -184,6 +184,47 @@ namespace ILRuntime.Runtime.Enviorment
                 return null;
         }*/
 
+        public static StackObject* IsAssignableFrom(ILIntepreter intp, StackObject* esp, IList<object> mStack, CLRMethod method, bool isNewObj)
+        {
+            var ret = ILIntepreter.Minus(esp, 2);
+            var p = esp - 1;
+            AppDomain dommain = intp.AppDomain;
+            var other = StackObject.ToObject(p, dommain, mStack);
+            intp.Free(p);
+            p = ILIntepreter.Minus(esp, 2);
+            var instance = StackObject.ToObject(p, dommain, mStack);
+            intp.Free(p);
+            if (instance is ILRuntimeType)
+            {
+                if (other is ILRuntimeType)
+                {
+                    if (((ILRuntimeType)instance).IsAssignableFrom((ILRuntimeType)other))
+                        return ILIntepreter.PushOne(ret);
+                    else
+                        return ILIntepreter.PushZero(ret);
+                }
+                else
+                    return ILIntepreter.PushZero(ret);
+            }
+            else
+            {
+                if (instance is ILRuntimeWrapperType)
+                {
+                    if (((ILRuntimeWrapperType)instance).IsAssignableFrom((Type)other))
+                        return ILIntepreter.PushOne(ret);
+                    else
+                        return ILIntepreter.PushZero(ret);
+                }
+                else
+                {
+                    if (((Type)instance).IsAssignableFrom((Type)other))
+                        return ILIntepreter.PushOne(ret);
+                    else
+                        return ILIntepreter.PushZero(ret);
+                }
+            }
+        }
+
         public unsafe static StackObject* InitializeArray(ILIntepreter intp, StackObject* esp, IList<object> mStack, CLRMethod method, bool isNewObj)
         {
             var ret = esp - 1 - 1;


### PR DESCRIPTION
例子XmlFieldListAttribute继承Attribute,
typeof(Attribute).IsAssignableFrom(typeof(XmlFieldListAttribute))的返回值是false。