### PR TITLE
优化CLRType.GetMethod(缓存CLRMethod.GenericParameterCount)、DelegateManager.FindDelegateAdapter消耗

### DIFF
--- a/ILRuntime/CLR/Method/CLRMethod.cs
+++ b/ILRuntime/CLR/Method/CLRMethod.cs
@@ -51,17 +51,23 @@ namespace ILRuntime.CLR.Method
                 return isConstructor ? !cDef.IsStatic : !def.IsStatic;
             }
         }
+
+        int _genericParameterCount = -1;
         public int GenericParameterCount
         {
             get
             {
-                if (def.ContainsGenericParameters && def.IsGenericMethodDefinition)
+                if (_genericParameterCount == -1)
                 {
-                    return def.GetGenericArguments().Length;
+                    if (def.ContainsGenericParameters && def.IsGenericMethodDefinition)
+                        _genericParameterCount = def.GetGenericArguments().Length;
+                    else
+                        _genericParameterCount = 0;
                 }
-                return 0;
+                return _genericParameterCount;
             }
         }
+
         public bool IsGenericInstance
         {
             get

--- a/ILRuntime/CLR/TypeSystem/CLRType.cs
+++ b/ILRuntime/CLR/TypeSystem/CLRType.cs
@@ -774,14 +774,16 @@ namespace ILRuntime.CLR.TypeSystem
             IMethod genericMethod = null;
             if (methods.TryGetValue(name, out lst))
             {
+                var paramCount = param.Count;
+
                 foreach (var i in lst)
                 {
-                    if (i.ParameterCount == param.Count)
+                    if (i.ParameterCount == paramCount)
                     {
                         bool match = true;
                         if (genericArguments != null && i.GenericParameterCount == genericArguments.Length)
                         {
-                            for (int j = 0; j < param.Count; j++)
+                            for (int j = 0; j < paramCount; j++)
                             {
                                 var p = i.Parameters[j].TypeForCLR;
                                 var q = param[j].TypeForCLR;
@@ -810,18 +812,19 @@ namespace ILRuntime.CLR.TypeSystem
                         }
                         else
                         {
+                            var iGenericArguments = i.GenericArguments;
                             if (genericArguments == null)
-                                match = i.GenericArguments == null;
+                                match = iGenericArguments == null;
                             else
                             {
-                                if (i.GenericArguments == null)
+                                if (iGenericArguments == null)
                                     match = false;
                                 else
-                                    match = i.GenericArguments.Length == genericArguments.Length;
+                                    match = iGenericArguments.Length == genericArguments.Length;
                             }
                             if (!match)
                                 continue;
-                            for (int j = 0; j < param.Count; j++)
+                            for (int j = 0; j < paramCount; j++)
                             {
                                 var typeA = /*param[j].TypeForCLR.IsByRef ? param[j].TypeForCLR.GetElementType() : */param[j].TypeForCLR;
                                 var typeB = /*i.Parameters[j].TypeForCLR.IsByRef ? i.Parameters[j].TypeForCLR.GetElementType() : */i.Parameters[j].TypeForCLR;
@@ -848,11 +851,11 @@ namespace ILRuntime.CLR.TypeSystem
 
                                 if (i.IsGenericInstance)
                                 {
-                                    if (i.GenericArguments.Length == genericArguments.Length)
+                                    if (iGenericArguments.Length == genericArguments.Length)
                                     {
                                         for (int j = 0; j < genericArguments.Length; j++)
                                         {
-                                            if (i.GenericArguments[j] != genericArguments[j])
+                                            if (iGenericArguments[j] != genericArguments[j])
                                             {
                                                 match = false;
                                                 break;

--- a/ILRuntime/Runtime/Enviorment/DelegateManager.cs
+++ b/ILRuntime/Runtime/Enviorment/DelegateManager.cs
@@ -240,9 +240,11 @@ namespace ILRuntime.Runtime.Enviorment
         internal IDelegateAdapter FindDelegateAdapter(ILTypeInstance instance, ILMethod ilMethod, IMethod method)
         {
             IDelegateAdapter res;
+            var parameterCount = method.ParameterCount;
+            var returnTypeForCLR = method.ReturnType.TypeForCLR;
             if (method.ReturnType == appdomain.VoidType)
             {
-                if (method.ParameterCount == 0)
+                if (parameterCount == 0)
                 {
                     res = zeroParamMethodAdapter.Instantiate(appdomain, instance, ilMethod);
                     if (instance != null)
@@ -251,12 +253,13 @@ namespace ILRuntime.Runtime.Enviorment
                 }
                 foreach (var i in methods)
                 {
-                    if (i.ParameterTypes.Length == method.ParameterCount)
+                    var parameterTypes = i.ParameterTypes;
+                    if (parameterTypes.Length == parameterCount)
                     {
                         bool match = true;
-                        for (int j = 0; j < method.ParameterCount; j++)
+                        for (int j = 0; j < parameterCount; j++)
                         {
-                            if (i.ParameterTypes[j] != method.Parameters[j].TypeForCLR)
+                            if (parameterTypes[j] != method.Parameters[j].TypeForCLR)
                             {
                                 match = false;
                                 break;
@@ -274,14 +277,16 @@ namespace ILRuntime.Runtime.Enviorment
             }
             else
             {
+
                 foreach (var i in functions)
                 {
-                    if (i.ParameterTypes.Length == method.ParameterCount + 1)
+                    var parameterTypes = i.ParameterTypes;
+                    if (parameterTypes.Length == parameterCount + 1)
                     {
                         bool match = true;
-                        for (int j = 0; j < method.ParameterCount; j++)
+                        for (int j = 0; j < parameterCount; j++)
                         {
-                            if (i.ParameterTypes[j] != method.Parameters[j].TypeForCLR)
+                            if (parameterTypes[j] != method.Parameters[j].TypeForCLR)
                             {
                                 match = false;
                                 break;
@@ -289,7 +294,7 @@ namespace ILRuntime.Runtime.Enviorment
                         }
                         if (match)
                         {
-                            if (method.ReturnType.TypeForCLR == i.ParameterTypes[method.ParameterCount])
+                            if (returnTypeForCLR == parameterTypes[parameterCount])
                             {
                                 res = i.Adapter.Instantiate(appdomain, instance, ilMethod);
                                 if (instance != null)


### PR DESCRIPTION
优化前
![image](https://user-images.githubusercontent.com/40783070/129473320-ee95ffec-7176-4afb-9387-d9d60e03f34d.png)

优化后
![image](https://user-images.githubusercontent.com/40783070/129473573-a1cea7b6-7784-4917-a1c6-b5d4d48c04d0.png)



