### PR TITLE
Supported CLRBinding in thread

### DIFF
--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -15,6 +15,7 @@ using ILRuntime.Runtime.Debugger;
 using ILRuntime.Runtime.Stack;
 using ILRuntime.Other;
 using ILRuntime.Runtime.Intepreter.RegisterVM;
+using System.Threading.Tasks;
 
 namespace ILRuntime.Runtime.Enviorment
 {
@@ -213,15 +214,149 @@ namespace ILRuntime.Runtime.Enviorment
         /// Attention, this property isn't thread safe
         /// </summary>
         public Dictionary<string, IType> LoadedTypes { get { return mapType.InnerDictionary; } }
-        internal Dictionary<MethodBase, CLRRedirectionDelegate> RedirectMap { get { return redirectMap; } }
-        internal Dictionary<FieldInfo, CLRFieldGetterDelegate> FieldGetterMap { get { return fieldGetterMap; } }
-        internal Dictionary<FieldInfo, CLRFieldSetterDelegate> FieldSetterMap { get { return fieldSetterMap; } }
-        internal Dictionary<FieldInfo, KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>> FieldBindingMap { get { return fieldBindingMap; } }
-        internal Dictionary<Type, CLRMemberwiseCloneDelegate> MemberwiseCloneMap { get { return memberwiseCloneMap; } }
-        internal Dictionary<Type, CLRCreateDefaultInstanceDelegate> CreateDefaultInstanceMap { get { return createDefaultInstanceMap; } }
-        internal Dictionary<Type, CLRCreateArrayInstanceDelegate> CreateArrayInstanceMap { get { return createArrayInstanceMap; } }
+
+        bool IsThreadBinding = false;
+        bool IsBindingDone = false;
+        static object bindingLockObject = new object();
+        internal Dictionary<MethodBase, CLRRedirectionDelegate> RedirectMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return redirectMap;
+                }
+                else
+                {
+                    lock(bindingLockObject)
+                    {
+                        return redirectMap;
+                    }
+                }
+            } 
+        }
+        internal Dictionary<FieldInfo, CLRFieldGetterDelegate> FieldGetterMap
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldGetterMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldGetterMap;
+                    }
+                }
+            } 
+        }
+        internal Dictionary<FieldInfo, CLRFieldSetterDelegate> FieldSetterMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldSetterMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldSetterMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<FieldInfo, KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>> FieldBindingMap 
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldBindingMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldBindingMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<Type, CLRMemberwiseCloneDelegate> MemberwiseCloneMap 
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return memberwiseCloneMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return memberwiseCloneMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<Type, CLRCreateDefaultInstanceDelegate> CreateDefaultInstanceMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return createDefaultInstanceMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return createDefaultInstanceMap;
+                    }
+                }
+            } 
+        }
+
+        internal Dictionary<Type, CLRCreateArrayInstanceDelegate> CreateArrayInstanceMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return createArrayInstanceMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return createArrayInstanceMap;
+                    }
+                }
+            }
+        }
         internal Dictionary<Type, CrossBindingAdaptor> CrossBindingAdaptors { get { return crossAdaptors; } }
-        internal Dictionary<Type, ValueTypeBinder> ValueTypeBinders { get { return valueTypeBinders; } }
+
+        internal Dictionary<Type, ValueTypeBinder> ValueTypeBinders 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return valueTypeBinders;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return valueTypeBinders;
+                    }
+                }
+            }
+        }
         public DebugService DebugService { get { return debugService; } }
         internal Dictionary<int, ILIntepreter> Intepreters { get { return intepreters; } }
         internal Queue<ILIntepreter> FreeIntepreters { get { return freeIntepreters; } }
@@ -484,55 +619,179 @@ namespace ILRuntime.Runtime.Enviorment
         {
             if (mi == null)
                 return;
-            if (!redirectMap.ContainsKey(mi))
-                redirectMap[mi] = func;
+
+            if (!IsThreadBinding)
+            {
+                if (!redirectMap.ContainsKey(mi))
+                    redirectMap[mi] = func;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!redirectMap.ContainsKey(mi))
+                        redirectMap[mi] = func;
+                }
+            }
+            
         }
 
         public void RegisterCLRFieldGetter(FieldInfo f, CLRFieldGetterDelegate getter)
         {
-            if (!fieldGetterMap.ContainsKey(f))
-                fieldGetterMap[f] = getter;
+            if (!IsThreadBinding)
+            {
+                if (!fieldGetterMap.ContainsKey(f))
+                    fieldGetterMap[f] = getter;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldGetterMap.ContainsKey(f))
+                        fieldGetterMap[f] = getter;
+                }
+            }
         }
 
         public void RegisterCLRFieldSetter(FieldInfo f, CLRFieldSetterDelegate setter)
         {
-            if (!fieldSetterMap.ContainsKey(f))
-                fieldSetterMap[f] = setter;
+            if (!IsThreadBinding)
+            {
+                if (!fieldSetterMap.ContainsKey(f))
+                    fieldSetterMap[f] = setter;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldSetterMap.ContainsKey(f))
+                        fieldSetterMap[f] = setter;
+                }
+            }
         }
 
         public void RegisterCLRFieldBinding(FieldInfo f, CLRFieldBindingDelegate copyToStack, CLRFieldBindingDelegate assignFromStack)
         {
-            if (!fieldBindingMap.ContainsKey(f))
-                fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+            if (!IsThreadBinding)
+            {
+                if (!fieldBindingMap.ContainsKey(f))
+                    fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldBindingMap.ContainsKey(f))
+                        fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+                }
+            }
         }
 
         public void RegisterCLRMemberwiseClone(Type t, CLRMemberwiseCloneDelegate memberwiseClone)
         {
-            if (!memberwiseCloneMap.ContainsKey(t))
-                memberwiseCloneMap[t] = memberwiseClone;
+            if (!IsThreadBinding)
+            {
+                if (!memberwiseCloneMap.ContainsKey(t))
+                    memberwiseCloneMap[t] = memberwiseClone;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!memberwiseCloneMap.ContainsKey(t))
+                        memberwiseCloneMap[t] = memberwiseClone;
+                }
+            }
         }
 
         public void RegisterCLRCreateDefaultInstance(Type t, CLRCreateDefaultInstanceDelegate createDefaultInstance)
         {
-            if (!createDefaultInstanceMap.ContainsKey(t))
-                createDefaultInstanceMap[t] = createDefaultInstance;
+            if (!IsThreadBinding)
+            {
+                if (!createDefaultInstanceMap.ContainsKey(t))
+                    createDefaultInstanceMap[t] = createDefaultInstance;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!createDefaultInstanceMap.ContainsKey(t))
+                        createDefaultInstanceMap[t] = createDefaultInstance;
+                }
+            }
         }
 
         public void RegisterCLRCreateArrayInstance(Type t, CLRCreateArrayInstanceDelegate createArray)
         {
-            if (!createArrayInstanceMap.ContainsKey(t))
-                createArrayInstanceMap[t] = createArray;
+            if (!IsThreadBinding)
+            {
+                if (!createArrayInstanceMap.ContainsKey(t))
+                    createArrayInstanceMap[t] = createArray;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!createArrayInstanceMap.ContainsKey(t))
+                        createArrayInstanceMap[t] = createArray;
+                }
+            }
         }
 
         public void RegisterValueTypeBinder(Type t, ValueTypeBinder binder)
         {
-            if (!valueTypeBinders.ContainsKey(t))
+            if (!IsThreadBinding)
             {
-                valueTypeBinders[t] = binder;
-                binder.RegisterCLRRedirection(this);
+                if (!valueTypeBinders.ContainsKey(t))
+                {
+                    valueTypeBinders[t] = binder;
+                    binder.RegisterCLRRedirection(this);
 
-                var ct = GetType(t) as CLRType;
-                binder.CLRType = ct;
+                    var ct = GetType(t) as CLRType;
+                    binder.CLRType = ct;
+                }
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!valueTypeBinders.ContainsKey(t))
+                    {
+                        valueTypeBinders[t] = binder;
+                        binder.RegisterCLRRedirection(this);
+
+                        var ct = GetType(t) as CLRType;
+                        binder.CLRType = ct;
+                    }
+                }
+            }
+            
+        }
+
+        /// <summary>
+        /// 初始化注册Bindings(开启线程做binding没完成时，获取CLR重定向方法会有些消耗)
+        /// </summary>
+        /// <param name="isThread"></param>
+        public void InitializeBindings(bool isThread = false)
+        {
+            if (IsBindingDone) 
+                return;
+
+            IsThreadBinding = isThread;
+
+            if (isThread)
+            {
+                Task.Factory.StartNew(() =>
+                {
+                    CLRBinding.CLRBindingUtils.Initialize(this);
+
+                    IsBindingDone = true;   //这里线程没有竞争写
+                });
+            }
+            else
+            {
+                CLRBinding.CLRBindingUtils.Initialize(this);
+                IsBindingDone = true;
             }
         }
 


### PR DESCRIPTION
思路大概是这样的
1、开一个线程去做binding
2、binding过程中，主线程（解释器）拿CLR重定向方法时加锁
3、binding结束后取消锁
4、初始化直接内聚在AppDomain里

* AppDomain.InitializeBindings(true);
* 子线程binding未结束时，主线程拿CLR重定向方法时因为加锁会有些消耗