### PR TITLE
Optimized #541

### DIFF
--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -1224,6 +1224,22 @@ namespace ILRuntime.Runtime.Enviorment
             else
                 throw new NotSupportedException("Cannot invoke CLRMethod");
         }
+        
+
+        bool IsInvalidMethodReference(MethodReference _ref)
+        {
+            if ((_ref.DeclaringType.Name == "Object" || _ref.DeclaringType.Name == "Attribute")
+                    && _ref.Name == ".ctor"
+                    && _ref.DeclaringType.Namespace == "System"
+                    && _ref.ReturnType.Name == "Void"
+                    && _ref.ReturnType.Namespace == "System")
+            {
+                return true;
+            }
+            return false;
+        }
+        
+        
         internal IMethod GetMethod(object token, ILType contextType, ILMethod contextMethod, out bool invalidToken)
         {
             string methodname = null;
@@ -1241,17 +1257,13 @@ namespace ILRuntime.Runtime.Enviorment
             if (token is Mono.Cecil.MethodReference)
             {
                 Mono.Cecil.MethodReference _ref = (token as Mono.Cecil.MethodReference);
-                var refFullName = _ref.FullName;
-                if (refFullName == "System.Void System.Object::.ctor()")
+
+                if(IsInvalidMethodReference(_ref))
                 {
                     mapMethod[hashCode] = null;
                     return null;
                 }
-                if (refFullName == "System.Void System.Attribute::.ctor()")
-                {
-                    mapMethod[hashCode] = null;
-                    return null;
-                }
+                
                 methodname = _ref.Name;
                 var typeDef = _ref.DeclaringType;
                 type = GetType(typeDef, contextType, contextMethod);


### PR DESCRIPTION
AppDomain.GetMethod 中 MethodReference.FullName会产生GC，虽然单次调用gc不高，但是由于AppDomain.GetMethod高频调用， 一旦执行栈比较深的话， 产生的GC还是比较高的，使用以下方法判断，能降低GC总量，效率也比较高。只是丑了点
```
        //丑陋的代码，但是很有效
        bool IsInvalidMethodReference(MethodReference _ref)
        {
            if ((_ref.DeclaringType.Name == "Object" || _ref.DeclaringType.Name == "Attribute")
                    && _ref.Name == ".ctor"
                    && _ref.DeclaringType.Namespace == "System"
                    && _ref.ReturnType.Name == "Void"
                    && _ref.ReturnType.Namespace == "System")
            {
                return true;
            }
            return false;
        }
```

![image](https://user-images.githubusercontent.com/40783070/131653769-f6af4348-3d73-445a-9f38-9bd410cf0ac9.png)
![1630490935582_06EA50CE-A569-4b86-8106-731973A55B6F](https://user-images.githubusercontent.com/40783070/131653786-10dde104-f429-46a2-b595-dbe727a0515f.png)

