### PR TITLE
修复 #588

### DIFF
--- a/ILRuntime/CLR/TypeSystem/CLRType.cs
+++ b/ILRuntime/CLR/TypeSystem/CLRType.cs
@@ -561,11 +561,11 @@ namespace ILRuntime.CLR.TypeSystem
         public IMethod GetVirtualMethod(IMethod method)
         {
             var m = GetMethod(method.Name, method.Parameters, null, method.ReturnType);
-            if (m == null)
-            {
-                return method;
-            }
-            else
+            //if (m == null)
+            //{
+            //    return method;
+            //}
+            //else
                 return m;
         }
 


### PR DESCRIPTION
调用接口方法时在`ILType.cs`761行`GetVirtualMethod`方法中在本类（HotModule.MyClass）方法中寻找名为“MyMethod”的方法，但是本类中使用显示实现，实际方法名为“HotModule.MyInterface.MyMethod”所以找不到。接下来在在父类中寻找，由于父类是个适配器，本质上是`CLRType`，所以代码执行到了`CLRType.cs`561行`GetVirtualMethod`方法中，这个适配中显然没有名为“MyMethod”的方法所以返回空，但是返回空以后却返回了参数表示的接口方法。由于接口方法不包含任何代码，所以造成了截图中的异常。注释掉`CLRType.cs`中564至568行即可修复此问题。