### PR TITLE
Supported CLRBindings in thread. Optimized AppDomain.ParseGenericType.

### DIFF
--- a/ILRuntime/CLR/Method/CLRMethod.cs
+++ b/ILRuntime/CLR/Method/CLRMethod.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-
-using ILRuntime.Mono.Cecil;
-using ILRuntime.Runtime.Intepreter;
-using ILRuntime.Runtime.Enviorment;
-using ILRuntime.CLR.TypeSystem;
-using ILRuntime.Runtime.Stack;
+﻿using ILRuntime.CLR.TypeSystem;
 using ILRuntime.CLR.Utils;
+using ILRuntime.Runtime.Enviorment;
+using ILRuntime.Runtime.Intepreter;
+using ILRuntime.Runtime.Stack;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 namespace ILRuntime.CLR.Method
 {
     public class CLRMethod : IMethod
@@ -20,7 +16,6 @@ namespace ILRuntime.CLR.Method
         ParameterInfo[] parametersCLR;
         ILRuntime.Runtime.Enviorment.AppDomain appdomain;
         CLRType declaringType;
-        ParameterInfo[] param;
         bool isConstructor;
         CLRRedirectionDelegate redirect;
         IType[] genericArguments;
@@ -95,7 +90,31 @@ namespace ILRuntime.CLR.Method
             }
         }
 
-        public CLRRedirectionDelegate Redirection { get { return redirect; } }
+        public CLRRedirectionDelegate Redirection
+        {
+            get
+            {
+                if (redirect == null)
+                {
+                    if (def != null)
+                    {
+                        if (def.IsGenericMethod && !def.IsGenericMethodDefinition)
+                        {
+                            //Redirection of Generic method Definition will be prioritized
+                            if (!appdomain.RedirectMap.TryGetValue(def.GetGenericMethodDefinition(), out redirect))
+                                appdomain.RedirectMap.TryGetValue(def, out redirect);
+                        }
+                        else
+                            appdomain.RedirectMap.TryGetValue(def, out redirect);
+                    }
+                    else if (cDef != null)
+                    {
+                        appdomain.RedirectMap.TryGetValue(cDef, out redirect);
+                    }
+                }
+                return redirect;
+            }
+        }
 
         public MethodInfo MethodInfo { get { return def; } }
 
@@ -107,7 +126,7 @@ namespace ILRuntime.CLR.Method
         {
             get
             {
-                if(genericArgumentsCLR == null)
+                if (genericArgumentsCLR == null)
                 {
                     if (cDef != null)
                         genericArgumentsCLR = cDef.GetGenericArguments();
@@ -123,7 +142,6 @@ namespace ILRuntime.CLR.Method
             this.def = def;
             declaringType = type;
             this.appdomain = domain;
-            param = def.GetParameters();
             if (!def.ContainsGenericParameters)
             {
                 ReturnType = domain.GetType(def.ReturnType.FullName);
@@ -135,42 +153,24 @@ namespace ILRuntime.CLR.Method
             if (type.IsDelegate && def.Name == "Invoke")
                 isDelegateInvoke = true;
             isConstructor = false;
-
-            if (def != null)
-            {
-                if (def.IsGenericMethod && !def.IsGenericMethodDefinition)
-                {
-                    //Redirection of Generic method Definition will be prioritized
-                    if(!appdomain.RedirectMap.TryGetValue(def.GetGenericMethodDefinition(), out redirect))
-                        appdomain.RedirectMap.TryGetValue(def, out redirect);
-                }
-                else
-                    appdomain.RedirectMap.TryGetValue(def, out redirect);
-            }
         }
         internal CLRMethod(ConstructorInfo def, CLRType type, ILRuntime.Runtime.Enviorment.AppDomain domain)
         {
             this.cDef = def;
             declaringType = type;
             this.appdomain = domain;
-            param = def.GetParameters();
             if (!def.ContainsGenericParameters)
             {
                 ReturnType = type;
             }
             isConstructor = true;
-
-            if (def != null)
-            {
-                appdomain.RedirectMap.TryGetValue(cDef, out redirect);
-            }
         }
 
         public int ParameterCount
         {
             get
             {
-                return param != null ? param.Length : 0;
+                return Parameters.Count;
             }
         }
 
@@ -191,7 +191,7 @@ namespace ILRuntime.CLR.Method
         {
             get
             {
-                if(parametersCLR == null)
+                if (parametersCLR == null)
                 {
                     if (cDef != null)
                         parametersCLR = cDef.GetParameters();
@@ -219,7 +219,7 @@ namespace ILRuntime.CLR.Method
         void InitParameters()
         {
             parameters = new List<IType>();
-            foreach (var i in param)
+            foreach (var i in ParametersCLR)
             {
                 IType type = appdomain.GetType(i.ParameterType.FullName);
                 if (type == null)
@@ -266,7 +266,7 @@ namespace ILRuntime.CLR.Method
             for (int i = paramCount; i >= 1; i--)
             {
                 var p = Minus(esp, i);
-                var pt = this.param[paramCount - i].ParameterType;
+                var pt = this.ParametersCLR[paramCount - i].ParameterType;
                 var obj = pt.CheckCLRTypes(StackObject.ToObject(p, appdomain, mStack));
                 obj = ILIntepreter.CheckAndCloneValueType(obj, appdomain);
                 param[paramCount - i] = obj;
@@ -329,7 +329,7 @@ namespace ILRuntime.CLR.Method
             }
         }
 
-        unsafe void FixReference(int paramCount, StackObject* esp, object[] param, IList<object> mStack,object instance, bool hasThis)
+        unsafe void FixReference(int paramCount, StackObject* esp, object[] param, IList<object> mStack, object instance, bool hasThis)
         {
             var cnt = hasThis ? paramCount + 1 : paramCount;
             for (int i = cnt; i >= 1; i--)
@@ -358,7 +358,7 @@ namespace ILRuntime.CLR.Method
                     case ObjectTypes.FieldReference:
                         {
                             var obj = mStack[p->Value];
-                            if(obj is ILTypeInstance)
+                            if (obj is ILTypeInstance)
                             {
                                 ((ILTypeInstance)obj)[p->ValueLow] = val;
                             }
@@ -372,7 +372,7 @@ namespace ILRuntime.CLR.Method
                     case ObjectTypes.StaticFieldReference:
                         {
                             var t = appdomain.GetType(p->Value);
-                            if(t is ILType)
+                            if (t is ILType)
                             {
                                 ((ILType)t).StaticInstance[p->ValueLow] = val;
                             }

--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -15,6 +15,7 @@ using ILRuntime.Runtime.Debugger;
 using ILRuntime.Runtime.Stack;
 using ILRuntime.Other;
 using ILRuntime.Runtime.Intepreter.RegisterVM;
+using System.Threading;
 
 namespace ILRuntime.Runtime.Enviorment
 {
@@ -213,15 +214,149 @@ namespace ILRuntime.Runtime.Enviorment
         /// Attention, this property isn't thread safe
         /// </summary>
         public Dictionary<string, IType> LoadedTypes { get { return mapType.InnerDictionary; } }
-        internal Dictionary<MethodBase, CLRRedirectionDelegate> RedirectMap { get { return redirectMap; } }
-        internal Dictionary<FieldInfo, CLRFieldGetterDelegate> FieldGetterMap { get { return fieldGetterMap; } }
-        internal Dictionary<FieldInfo, CLRFieldSetterDelegate> FieldSetterMap { get { return fieldSetterMap; } }
-        internal Dictionary<FieldInfo, KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>> FieldBindingMap { get { return fieldBindingMap; } }
-        internal Dictionary<Type, CLRMemberwiseCloneDelegate> MemberwiseCloneMap { get { return memberwiseCloneMap; } }
-        internal Dictionary<Type, CLRCreateDefaultInstanceDelegate> CreateDefaultInstanceMap { get { return createDefaultInstanceMap; } }
-        internal Dictionary<Type, CLRCreateArrayInstanceDelegate> CreateArrayInstanceMap { get { return createArrayInstanceMap; } }
+
+        bool IsThreadBinding = false;
+        bool IsBindingDone = false;
+        static object bindingLockObject = new object();
+        internal Dictionary<MethodBase, CLRRedirectionDelegate> RedirectMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return redirectMap;
+                }
+                else
+                {
+                    lock(bindingLockObject)
+                    {
+                        return redirectMap;
+                    }
+                }
+            } 
+        }
+        internal Dictionary<FieldInfo, CLRFieldGetterDelegate> FieldGetterMap
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldGetterMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldGetterMap;
+                    }
+                }
+            } 
+        }
+        internal Dictionary<FieldInfo, CLRFieldSetterDelegate> FieldSetterMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldSetterMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldSetterMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<FieldInfo, KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>> FieldBindingMap 
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return fieldBindingMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return fieldBindingMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<Type, CLRMemberwiseCloneDelegate> MemberwiseCloneMap 
+        {
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return memberwiseCloneMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return memberwiseCloneMap;
+                    }
+                }
+            }
+        }
+        internal Dictionary<Type, CLRCreateDefaultInstanceDelegate> CreateDefaultInstanceMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return createDefaultInstanceMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return createDefaultInstanceMap;
+                    }
+                }
+            } 
+        }
+
+        internal Dictionary<Type, CLRCreateArrayInstanceDelegate> CreateArrayInstanceMap 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return createArrayInstanceMap;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return createArrayInstanceMap;
+                    }
+                }
+            }
+        }
         internal Dictionary<Type, CrossBindingAdaptor> CrossBindingAdaptors { get { return crossAdaptors; } }
-        internal Dictionary<Type, ValueTypeBinder> ValueTypeBinders { get { return valueTypeBinders; } }
+
+        internal Dictionary<Type, ValueTypeBinder> ValueTypeBinders 
+        { 
+            get 
+            {
+                if (!IsThreadBinding && IsBindingDone)
+                {
+                    return valueTypeBinders;
+                }
+                else
+                {
+                    lock (bindingLockObject)
+                    {
+                        return valueTypeBinders;
+                    }
+                }
+            }
+        }
         public DebugService DebugService { get { return debugService; } }
         internal Dictionary<int, ILIntepreter> Intepreters { get { return intepreters; } }
         internal Queue<ILIntepreter> FreeIntepreters { get { return freeIntepreters; } }
@@ -484,55 +619,185 @@ namespace ILRuntime.Runtime.Enviorment
         {
             if (mi == null)
                 return;
-            if (!redirectMap.ContainsKey(mi))
-                redirectMap[mi] = func;
+
+            if (!IsThreadBinding)
+            {
+                if (!redirectMap.ContainsKey(mi))
+                    redirectMap[mi] = func;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!redirectMap.ContainsKey(mi))
+                        redirectMap[mi] = func;
+                }
+            }
+            
         }
 
         public void RegisterCLRFieldGetter(FieldInfo f, CLRFieldGetterDelegate getter)
         {
-            if (!fieldGetterMap.ContainsKey(f))
-                fieldGetterMap[f] = getter;
+            if (!IsThreadBinding)
+            {
+                if (!fieldGetterMap.ContainsKey(f))
+                    fieldGetterMap[f] = getter;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldGetterMap.ContainsKey(f))
+                        fieldGetterMap[f] = getter;
+                }
+            }
         }
 
         public void RegisterCLRFieldSetter(FieldInfo f, CLRFieldSetterDelegate setter)
         {
-            if (!fieldSetterMap.ContainsKey(f))
-                fieldSetterMap[f] = setter;
+            if (!IsThreadBinding)
+            {
+                if (!fieldSetterMap.ContainsKey(f))
+                    fieldSetterMap[f] = setter;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldSetterMap.ContainsKey(f))
+                        fieldSetterMap[f] = setter;
+                }
+            }
         }
 
         public void RegisterCLRFieldBinding(FieldInfo f, CLRFieldBindingDelegate copyToStack, CLRFieldBindingDelegate assignFromStack)
         {
-            if (!fieldBindingMap.ContainsKey(f))
-                fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+            if (!IsThreadBinding)
+            {
+                if (!fieldBindingMap.ContainsKey(f))
+                    fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!fieldBindingMap.ContainsKey(f))
+                        fieldBindingMap[f] = new KeyValuePair<CLRFieldBindingDelegate, CLRFieldBindingDelegate>(copyToStack, assignFromStack);
+                }
+            }
         }
 
         public void RegisterCLRMemberwiseClone(Type t, CLRMemberwiseCloneDelegate memberwiseClone)
         {
-            if (!memberwiseCloneMap.ContainsKey(t))
-                memberwiseCloneMap[t] = memberwiseClone;
+            if (!IsThreadBinding)
+            {
+                if (!memberwiseCloneMap.ContainsKey(t))
+                    memberwiseCloneMap[t] = memberwiseClone;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!memberwiseCloneMap.ContainsKey(t))
+                        memberwiseCloneMap[t] = memberwiseClone;
+                }
+            }
         }
 
         public void RegisterCLRCreateDefaultInstance(Type t, CLRCreateDefaultInstanceDelegate createDefaultInstance)
         {
-            if (!createDefaultInstanceMap.ContainsKey(t))
-                createDefaultInstanceMap[t] = createDefaultInstance;
+            if (!IsThreadBinding)
+            {
+                if (!createDefaultInstanceMap.ContainsKey(t))
+                    createDefaultInstanceMap[t] = createDefaultInstance;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!createDefaultInstanceMap.ContainsKey(t))
+                        createDefaultInstanceMap[t] = createDefaultInstance;
+                }
+            }
         }
 
         public void RegisterCLRCreateArrayInstance(Type t, CLRCreateArrayInstanceDelegate createArray)
         {
-            if (!createArrayInstanceMap.ContainsKey(t))
-                createArrayInstanceMap[t] = createArray;
+            if (!IsThreadBinding)
+            {
+                if (!createArrayInstanceMap.ContainsKey(t))
+                    createArrayInstanceMap[t] = createArray;
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!createArrayInstanceMap.ContainsKey(t))
+                        createArrayInstanceMap[t] = createArray;
+                }
+            }
         }
 
         public void RegisterValueTypeBinder(Type t, ValueTypeBinder binder)
         {
-            if (!valueTypeBinders.ContainsKey(t))
+            if (!IsThreadBinding)
             {
-                valueTypeBinders[t] = binder;
-                binder.RegisterCLRRedirection(this);
+                if (!valueTypeBinders.ContainsKey(t))
+                {
+                    valueTypeBinders[t] = binder;
+                    binder.RegisterCLRRedirection(this);
 
-                var ct = GetType(t) as CLRType;
-                binder.CLRType = ct;
+                    var ct = GetType(t) as CLRType;
+                    binder.CLRType = ct;
+                }
+            }
+            else
+            {
+                lock (bindingLockObject)
+                {
+                    if (!valueTypeBinders.ContainsKey(t))
+                    {
+                        valueTypeBinders[t] = binder;
+                        binder.RegisterCLRRedirection(this);
+
+                        var ct = GetType(t) as CLRType;
+                        binder.CLRType = ct;
+                    }
+                }
+            }
+            
+        }
+
+        /// <summary>
+        /// 初始化注册Bindings(开启线程做binding没完成时，获取CLR重定向方法会有些消耗)
+        /// </summary>
+        /// <param name="isThread"></param>
+        public void InitializeBindings(bool isThread = false)
+        {
+            if (IsBindingDone) 
+                return;
+
+            IsThreadBinding = isThread;
+
+            if (isThread)
+            {
+                Thread thread = new Thread(() =>
+                {
+                    CLRBinding.CLRBindingUtils.Initialize(this);
+
+                    IsBindingDone = true;   //这里线程没有竞争写
+
+#if DEBUG && !NO_PROFILER
+                    UnityEngine.Debug.Log("CLRBindingUtils.Initialize Done in thread..");
+#endif
+                });
+                thread.Name = $"CLRBindings-Thread #{thread.ManagedThreadId}";
+                thread.Start();
+            }
+            else
+            {
+                CLRBinding.CLRBindingUtils.Initialize(this);
+                IsBindingDone = true;
             }
         }
 
@@ -559,8 +824,7 @@ namespace ILRuntime.Runtime.Enviorment
             byte rank;
             ParseGenericType(fullname, out baseType, out genericParams, out isArray, out rank);
 
-
-            bool isByRef = baseType.EndsWith("&");
+            bool isByRef = !string.IsNullOrEmpty(baseType) && baseType[baseType.Length - 1] == '&';
             if (isByRef)
                 baseType = baseType.Substring(0, baseType.Length - 1);
             if (genericParams != null || isArray || isByRef)
@@ -674,7 +938,8 @@ namespace ILRuntime.Runtime.Enviorment
             rank = 0;
             baseType = "";
             genericParams = null;
-            if (fullname.Length > 2 && fullname.Substring(fullname.Length - 2) == "[]")
+
+            if (fullname.Length > 2 && fullname[fullname.Length - 2] == '[' && fullname[fullname.Length - 1] == ']')
             {
                 fullname = fullname.Substring(0, fullname.Length - 2);
                 rank = 1;
@@ -682,12 +947,21 @@ namespace ILRuntime.Runtime.Enviorment
             }
             else
                 isArray = false;
-            if (fullname.Length > 2 && fullname.Substring(fullname.Length - 2) == "[]")
+            if (fullname.Length > 2 && fullname[fullname.Length - 2] == '[' && fullname[fullname.Length - 1] == ']')
             {
                 baseType = fullname;
                 return;
             }
-            if (fullname.Contains('<') || fullname.Contains('['))
+            bool isGenericType = false;
+            foreach (var i in fullname)
+            {
+                if (i == '<' || i == '[')
+                {
+                    isGenericType = true;
+                    break;
+                }
+            }
+            if (isGenericType)
             {
                 foreach (var i in fullname)
                 {

--- a/ILRuntimeTest/TestMainForm.cs
+++ b/ILRuntimeTest/TestMainForm.cs
@@ -148,8 +148,8 @@ namespace ILRuntimeTest
                     }
 
                     ILRuntimeHelper.Init(_app);
-                    ILRuntime.Runtime.Generated.CLRBindings.Initialize(_app);
-
+                    //ILRuntime.Runtime.Generated.CLRBindings.Initialize(_app);
+                    _app.InitializeBindings(true);
                     LoadTest();
                     UpdateBtnState();
                 }


### PR DESCRIPTION
# 线程中绑定
思路大概是这样的
1、开一个线程去做binding
2、binding过程中，主线程（解释器）拿CLR重定向方法时加锁
3、binding结束后取消锁
4、初始化直接内聚在AppDomain里
5、AppDomain.InitializeBindings(true);//开放binding接口
6、子线程binding未结束时，主线程拿CLR重定向方法时因为加锁会有些消耗

# AppDomain部分性能优化
1、AppDomain.ParseGenericType 性能及GC优化
2、AppDomain.GetType 中 EndWiths优化（见下图）

# CLRMethod优化
1、移除param字段减少内存
2、def.GetParameters()懒加载
3、重定向懒获取（线程下binding时，可能会null，之后需要重新赋值）

![lQLPDhqjtu651pTNBCDNAoGwhWg5Mq7jRz_iijQC2j7SQw_641_1056](https://user-images.githubusercontent.com/40783070/131607670-8e35180c-b34f-49bd-89b9-3bc628f124b7.png)
