### PR TITLE
修复Binding结构体赋值时抛出的NotImplementedException异常

### DIFF
--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -4736,10 +4736,24 @@ namespace ILRuntime.Runtime.Intepreter
                     if (v->ObjectType == ObjectTypes.ValueTypeObjectReference)
                     {
                         CopyStackValueType(esp, v, mStack);
+                        FreeStackValueType(esp);
+                    }
+                    else if(v->ObjectType == ObjectTypes.Object)
+                    {
+                        var dst = ILIntepreter.ResolveReference(esp);
+                        if(dst != null)
+                        {
+                            var ct = domain.GetTypeByIndex(dst->Value) as CLRType;
+                            var binder = ct.ValueTypeBinder;
+                            v->ObjectType = ObjectTypes.ValueTypeObjectReference;
+                            int addr = ((IntPtr)dst).ToInt32();
+                            v->Value = addr;
+                        }
+                        else
+                            throw new NotImplementedException();
                     }
                     else
                         throw new NotImplementedException();
-                    FreeStackValueType(esp);
                     break;
                 default:
                     *v = *esp;

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -265,6 +265,8 @@ namespace ILRuntime.Runtime.Intepreter
                 bool returned = false;
                 while (!returned)
                 {
+                    try
+                    {
 #if DEBUG && !DISABLE_ILRUNTIME_DEBUG
                         if (ShouldBreak)
                             Break();
@@ -2229,14 +2231,14 @@ namespace ILRuntime.Runtime.Intepreter
                                         if (obj != null)
                                         {
                                             if (obj is ILTypeInstance)
-                                        {
-                                            ILTypeInstance instance = obj as ILTypeInstance;
-                                            instance.PushToStack((int)ip->TokenLong, ret, this, mStack);
-                                        }
-                                        else
-                                        {
-                                            //var t = obj.GetType();
-                                            type = AppDomain.GetType((int)(ip->TokenLong >> 32));
+                                            {
+                                                ILTypeInstance instance = obj as ILTypeInstance;
+                                                instance.PushToStack((int)ip->TokenLong, ret, this, mStack);
+                                            }
+                                            else
+                                            {
+                                                //var t = obj.GetType();
+                                                type = AppDomain.GetType((int)(ip->TokenLong >> 32));
                                                 if (type != null)
                                                 {
                                                     var token = (int)ip->TokenLong;
@@ -4435,7 +4437,72 @@ namespace ILRuntime.Runtime.Intepreter
                                 throw new NotSupportedException("Not supported opcode " + code);
                         }
                         ip++;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ehs != null)
+                        {
+                            int addr = (int)(ip - ptr);
+                            var eh = GetCorrespondingExceptionHandler(ehs, ex, addr, ExceptionHandlerType.Catch, true);
 
+                            if (eh == null)
+                            {
+                                eh = GetCorrespondingExceptionHandler(ehs, ex, addr, ExceptionHandlerType.Catch, false);
+                            }
+                            if (eh != null)
+                            {
+                                if (ex is ILRuntimeException)
+                                {
+                                    ILRuntimeException ire = (ILRuntimeException)ex;
+                                    var inner = ire.InnerException;
+                                    inner.Data["ThisInfo"] = ire.ThisInfo;
+                                    inner.Data["StackTrace"] = ire.StackTrace;
+                                    inner.Data["LocalInfo"] = ire.LocalInfo;
+                                    ex = inner;
+                                }
+                                else
+                                {
+                                    var debugger = AppDomain.DebugService;
+                                    if (method.HasThis)
+                                        ex.Data["ThisInfo"] = debugger.GetThisInfo(this);
+                                    else
+                                        ex.Data["ThisInfo"] = "";
+                                    ex.Data["StackTrace"] = debugger.GetStackTrace(this);
+                                    ex.Data["LocalInfo"] = debugger.GetLocalVariableInfo(this);
+                                }
+                                //Clear call stack
+                                while (stack.Frames.Peek().BasePointer != frame.BasePointer)
+                                {
+                                    var f = stack.Frames.Peek();
+                                    esp = stack.PopFrame(ref f, esp);
+                                    if (f.Method.ReturnType != AppDomain.VoidType)
+                                    {
+                                        Free(esp - 1);
+                                        esp--;
+                                    }
+                                }
+                                lastCaughtEx = ex;
+                                esp = PushObject(esp, mStack, ex);
+                                unhandledException = false;
+                                ip = ptr + eh.HandlerStart;
+                                continue;
+                            }
+                        }
+                        if (unhandledException)
+                        {
+                            throw ex;
+                        }
+
+                        unhandledException = true;
+                        returned = true;
+#if DEBUG && !DISABLE_ILRUNTIME_DEBUG
+                        if (!AppDomain.DebugService.Break(this, ex))
+#endif
+                        {
+                            var newEx = new ILRuntimeException(ex.Message, this, method, ex);
+                            throw newEx;
+                        }
+                    }
                 }
             }
 #if DEBUG && !NO_PROFILER
@@ -4669,25 +4736,10 @@ namespace ILRuntime.Runtime.Intepreter
                     if (v->ObjectType == ObjectTypes.ValueTypeObjectReference)
                     {
                         CopyStackValueType(esp, v, mStack);
-                        FreeStackValueType(esp);
-                    }
-                    else if(v->ObjectType == ObjectTypes.Object)
-                    {
-                        //直接把地址给到新的变量,所以并不释放esp空间
-                        var dst = ILIntepreter.ResolveReference(esp);
-                        if(dst != null)
-                        {
-                            var ct = domain.GetTypeByIndex(dst->Value) as CLRType;
-                            var binder = ct.ValueTypeBinder;
-                            v->ObjectType = ObjectTypes.ValueTypeObjectReference;
-                            int addr = ((IntPtr)dst).ToInt32();
-                            v->Value = addr;
-                        }
-                        else
-                            throw new NotImplementedException();
                     }
                     else
                         throw new NotImplementedException();
+                    FreeStackValueType(esp);
                     break;
                 default:
                     *v = *esp;

--- a/TestCases/TestValueTypeBinding.cs
+++ b/TestCases/TestValueTypeBinding.cs
@@ -477,5 +477,29 @@ namespace TestCases
             if(Math.Abs(arr2[0].X - 1244)>0.001f)
                 throw new Exception();
         }
+
+        public static void UnitTest_10048()
+        {
+            var pos = new TestVector3(0f, 0.8f, 0.5f);
+            var obj = pos as object;
+            UnitTest_10048Sub(obj);
+        }
+
+        static void UnitTest_10048Sub(object param = null)
+        {
+            var context = new UnitTest_10048Context( param);
+            object data = context.data;
+            Console.WriteLine("data:" + data.ToString());
+        }
+
+        public class UnitTest_10048Context
+        {
+            public object data;
+
+            public UnitTest_10048Context(object data = null)
+            {
+                this.data = data;
+            }
+        }
     }
 }

--- a/TestCases/TestValueTypeBinding.cs
+++ b/TestCases/TestValueTypeBinding.cs
@@ -477,29 +477,5 @@ namespace TestCases
             if(Math.Abs(arr2[0].X - 1244)>0.001f)
                 throw new Exception();
         }
-
-        public static void UnitTest_10048()
-        {
-            var pos = new TestVector3(0f, 0.8f, 0.5f);
-            var obj = pos as object;
-            UnitTest_10048Sub(obj);
-        }
-
-        static void UnitTest_10048Sub(object param = null)
-        {
-            var context = new UnitTest_10048Context( param);
-            object data = context.data;
-            Console.WriteLine("data:" + data.ToString());
-        }
-
-        public class UnitTest_10048Context
-        {
-            public object data;
-
-            public UnitTest_10048Context(object data = null)
-            {
-                this.data = data;
-            }
-        }
     }
 }


### PR DESCRIPTION
当一个做了值类型绑定的结构体赋值给一个object对象,并对一个新的object对象进行赋值时,会抛出NotImplementedException异常.