### PR TITLE
修复扩展方法作为委托使用时的报空问题

### DIFF
--- a/ILRuntime/CLR/Method/CLRMethod.cs
+++ b/ILRuntime/CLR/Method/CLRMethod.cs
@@ -439,5 +439,19 @@ namespace ILRuntime.CLR.Method
                 hashCode = System.Threading.Interlocked.Add(ref instance_id, 1);
             return hashCode;
         }
+
+
+        bool? isExtend;
+        public bool IsExtend
+        {
+            get
+            {
+                if (isExtend == null)
+                {
+                    isExtend = this.IsExtendMethod();
+                }
+                return isExtend.Value;
+            }
+        }
     }
 }

--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -961,5 +961,19 @@ namespace ILRuntime.CLR.Method
                 hashCode = System.Threading.Interlocked.Add(ref instance_id, 1);
             return hashCode;
         }
+
+
+        bool? isExtend;
+        public bool IsExtend
+        {
+            get
+            {
+                if (isExtend == null)
+                {
+                    isExtend = this.IsExtendMethod();
+                }
+                return isExtend.Value;
+            }
+        }
     }
 }

--- a/ILRuntime/CLR/Method/IMethod.cs
+++ b/ILRuntime/CLR/Method/IMethod.cs
@@ -29,5 +29,8 @@ namespace ILRuntime.CLR.Method
         bool IsStatic { get; }
 
         IMethod MakeGenericMethod(IType[] genericArguments);
+
+
+        bool IsExtend { get; }
     }
 }

--- a/ILRuntime/CLR/Method/IMethodExtensions.cs
+++ b/ILRuntime/CLR/Method/IMethodExtensions.cs
@@ -4,6 +4,10 @@
     {
         public static bool IsExtendMethod(this IMethod iLMethod)
         {
+            if (!iLMethod.IsStatic)
+            {
+                return false;
+            }
             return iLMethod.ParameterCount > 0 && iLMethod.DeclearingType.ReflectionType.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
         }
 

--- a/ILRuntime/CLR/Method/IMethodExtensions.cs
+++ b/ILRuntime/CLR/Method/IMethodExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace ILRuntime.CLR.Method
+{
+    public static class IMethodExtensions
+    {
+        public static bool IsExtendMethod(this IMethod iLMethod)
+        {
+            return iLMethod.ParameterCount > 0 && iLMethod.DeclearingType.ReflectionType.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
+        }
+
+    }
+}

--- a/ILRuntime/ILRuntime.csproj
+++ b/ILRuntime/ILRuntime.csproj
@@ -50,6 +50,7 @@
     <Compile Include="CLR\Method\ExceptionHandler.cs" />
     <Compile Include="CLR\Method\ILMethod.cs" />
     <Compile Include="CLR\Method\IMethod.cs" />
+    <Compile Include="CLR\Method\IMethodExtensions.cs" />
     <Compile Include="CLR\TypeSystem\ILGenericParameterType.cs" />
     <Compile Include="CLR\TypeSystem\ILType.cs" />
     <Compile Include="CLR\TypeSystem\CLRType.cs" />

--- a/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
+++ b/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
@@ -863,7 +863,7 @@ namespace ILRuntime.Runtime.Intepreter
             if (method.HasThis)
                 esp = ILIntepreter.PushObject(esp, mStack, instance);
             int paramCnt = method.ParameterCount;
-            if (method.IsExtendMethod())
+            if (method.IsExtend)
             {
                 esp = ILIntepreter.PushObject(esp, mStack, instance);
                 paramCnt--;
@@ -897,7 +897,7 @@ namespace ILRuntime.Runtime.Intepreter
         unsafe StackObject* ClearStack(ILIntepreter intp, StackObject* esp, StackObject* ebp, IList<object> mStack)
         {
             int paramCnt = method.ParameterCount;
-            if (method.IsExtendMethod())//如果是拓展方法，退一位
+            if (method.IsExtend)//如果是拓展方法，退一位
             {
                 paramCnt--;
             }

--- a/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
+++ b/ILRuntime/Runtime/Intepreter/DelegateAdapter.cs
@@ -863,6 +863,11 @@ namespace ILRuntime.Runtime.Intepreter
             if (method.HasThis)
                 esp = ILIntepreter.PushObject(esp, mStack, instance);
             int paramCnt = method.ParameterCount;
+            if (method.IsExtendMethod())
+            {
+                esp = ILIntepreter.PushObject(esp, mStack, instance);
+                paramCnt--;
+            }
             bool useRegister = method.ShouldUseRegisterVM;
             for (int i = paramCnt; i > 0; i--)
             {
@@ -892,6 +897,10 @@ namespace ILRuntime.Runtime.Intepreter
         unsafe StackObject* ClearStack(ILIntepreter intp, StackObject* esp, StackObject* ebp, IList<object> mStack)
         {
             int paramCnt = method.ParameterCount;
+            if (method.IsExtendMethod())//如果是拓展方法，退一位
+            {
+                paramCnt--;
+            }
             object retObj = null;
             StackObject retSObj = StackObject.Null;
             bool hasReturn = method.ReturnType != appdomain.VoidType;

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2650,7 +2650,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (dele == null)
                                                     {
                                                         var invokeMethod = type.GetMethod("Invoke", mi.ParameterCount);
-                                                        if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                        if (invokeMethod == null && ilMethod.IsExtend)
                                                         {
                                                             invokeMethod = type.GetMethod("Invoke", mi.ParameterCount - 1);
                                                         }
@@ -2763,7 +2763,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                             var invokeMethod =
                                                                 cm.DeclearingType.GetMethod("Invoke",
                                                                     mi.ParameterCount);
-                                                            if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                            if (invokeMethod == null && ilMethod.IsExtend)
                                                             {
                                                                 invokeMethod = cm.DeclearingType.GetMethod("Invoke", mi.ParameterCount - 1);
                                                             }

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2650,6 +2650,10 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (dele == null)
                                                     {
                                                         var invokeMethod = type.GetMethod("Invoke", mi.ParameterCount);
+                                                        if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                        {
+                                                            invokeMethod = type.GetMethod("Invoke", mi.ParameterCount - 1);
+                                                        }
                                                         dele = domain.DelegateManager.FindDelegateAdapter(
                                                             (ILTypeInstance) ins, ilMethod, invokeMethod);
                                                     }
@@ -2759,6 +2763,10 @@ namespace ILRuntime.Runtime.Intepreter
                                                             var invokeMethod =
                                                                 cm.DeclearingType.GetMethod("Invoke",
                                                                     mi.ParameterCount);
+                                                            if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                            {
+                                                                invokeMethod = cm.DeclearingType.GetMethod("Invoke", mi.ParameterCount - 1);
+                                                            }
                                                             dele = domain.DelegateManager.FindDelegateAdapter(
                                                                 (ILTypeInstance) ins, ilMethod, invokeMethod);
                                                         }

--- a/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
+++ b/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
@@ -3263,6 +3263,10 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (dele == null)
                                                     {
                                                         var invokeMethod = type.GetMethod("Invoke", mi.ParameterCount);
+                                                        if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                        {
+                                                            invokeMethod = type.GetMethod("Invoke", mi.ParameterCount - 1);
+                                                        }
                                                         dele = domain.DelegateManager.FindDelegateAdapter(
                                                             (ILTypeInstance)ins, ilMethod, invokeMethod);
                                                     }
@@ -3376,6 +3380,10 @@ namespace ILRuntime.Runtime.Intepreter
                                                             var invokeMethod =
                                                                 cm.DeclearingType.GetMethod("Invoke",
                                                                     mi.ParameterCount);
+                                                            if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                            {
+                                                                invokeMethod = cm.DeclearingType.GetMethod("Invoke", mi.ParameterCount - 1);
+                                                            }
                                                             dele = domain.DelegateManager.FindDelegateAdapter(
                                                                 (ILTypeInstance)ins, ilMethod, invokeMethod);
                                                         }

--- a/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
+++ b/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
@@ -3263,7 +3263,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                     if (dele == null)
                                                     {
                                                         var invokeMethod = type.GetMethod("Invoke", mi.ParameterCount);
-                                                        if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                        if (invokeMethod == null && ilMethod.IsExtend)
                                                         {
                                                             invokeMethod = type.GetMethod("Invoke", mi.ParameterCount - 1);
                                                         }
@@ -3380,7 +3380,7 @@ namespace ILRuntime.Runtime.Intepreter
                                                             var invokeMethod =
                                                                 cm.DeclearingType.GetMethod("Invoke",
                                                                     mi.ParameterCount);
-                                                            if (invokeMethod == null && ilMethod.IsExtendMethod())
+                                                            if (invokeMethod == null && ilMethod.IsExtend)
                                                             {
                                                                 invokeMethod = cm.DeclearingType.GetMethod("Invoke", mi.ParameterCount - 1);
                                                             }

--- a/TestCases/DelegateExtTest.cs
+++ b/TestCases/DelegateExtTest.cs
@@ -1,0 +1,119 @@
+﻿using System;
+
+namespace TestCases
+{
+    public class DelegateExtObj
+    {
+
+    }
+    public static class DelegateExtObjMethod
+    {
+
+        public static void IntTest(this DelegateExtObj obj, int a)
+        {
+            Console.WriteLine(obj + " dele a=" + a);
+        }
+
+        public static void IntTest2(this DelegateExtObj obj, int a)
+        {
+            Console.WriteLine(obj + " dele2 a=" + a);
+        }
+
+        public static int IntTest3(this DelegateExtObj obj, int a)
+        {
+            Console.WriteLine(obj + " dele3 a=" + a);
+            return a + 100;
+        }
+        public static string Void(this DelegateExtObj obj,string str)
+        {
+            Console.WriteLine(obj + " Void");
+            return "Void"+str+"x";
+        }
+        public static string Extend(this DelegateExtObj obj,string str)
+        {
+         
+            return "Extend";
+        }
+    }
+    public class DelegateExtTest
+    {
+
+
+        static TestDelegate testDele;
+
+        public static void DelegateExtTest01()
+        {
+            var obj = new DelegateExtObj();
+            ILRuntimeTest.TestFramework.DelegateTest.IntDelegateTest += obj.IntTest;
+            ILRuntimeTest.TestFramework.DelegateTest.IntDelegateTest += obj.IntTest2;
+
+
+        }
+
+        public static void DelegateExtTest02()
+        {
+            var obj = new DelegateExtObj();
+            Action<int> a = null;
+            a += obj.IntTest;
+            a += obj.IntTest2;
+
+            DelegateTestCls cls = new DelegateTestCls(1000);
+            a += cls.IntTest;
+            a += cls.IntTest2;
+            a += (i) =>
+            {
+                Console.WriteLine("lambda a=" + i);
+            };
+          
+        }
+        public static void DelegateExtTest03()
+        {
+            var obj = new DelegateExtObj();
+            Func<string,string> a = null;
+
+            a += obj.Void;
+            a += obj.Extend;
+            Console.WriteLine("a=" + a("xxzz"));
+        }
+        public static void DelegateExtTest04()
+        {
+            var obj = new DelegateExtObj();
+            Func<string> a = null;
+            var o1 = new DelegateTestCls(11);
+            a += o1.GetString;
+
+            Console.WriteLine("no extend method lambda a=" + a());
+        }
+        class DelegateTestCls : DelegateTestClsBase
+        {
+        
+            public DelegateTestCls(int b)
+            {
+                this.b = b;
+            }
+            public string GetString()
+            {
+                return "x";
+            }
+           
+        }
+
+        class DelegateTestClsBase
+        {
+            protected int b;
+            public virtual void IntTest(int a)
+            {
+                Console.WriteLine("dele3base a=" + (a + b));
+            }
+            public virtual void IntTest2(int a)
+            {
+                Console.WriteLine("dele4 a=" + (a + b));
+            }
+        }
+
+        delegate int TestDelegate(int b);
+
+
+
+    }
+}

--- a/TestCases/DelegateExtTest.cs
+++ b/TestCases/DelegateExtTest.cs
@@ -4,19 +4,25 @@ namespace TestCases
 {
     public class DelegateExtObj
     {
-
+        public int Value;
+        public void AddValue(int value)
+        {
+            this.Value += value;
+        }
     }
     public static class DelegateExtObjMethod
     {
 
         public static void IntTest(this DelegateExtObj obj, int a)
         {
+            obj.AddValue(1);
             Console.WriteLine(obj + " dele a=" + a);
         }
 
         public static void IntTest2(this DelegateExtObj obj, int a)
         {
-            Console.WriteLine(obj + " dele2 a=" + a);
+            obj.AddValue(123);
+            Console.WriteLine(obj + " dele2 a=" + obj.Value);
         }
 
         public static int IntTest3(this DelegateExtObj obj, int a)
@@ -57,6 +63,7 @@ namespace TestCases
             a += obj.IntTest;
             a += obj.IntTest2;
 
+
             DelegateTestCls cls = new DelegateTestCls(1000);
             a += cls.IntTest;
             a += cls.IntTest2;
@@ -64,7 +71,9 @@ namespace TestCases
             {
                 Console.WriteLine("lambda a=" + i);
             };
-          
+            a.Invoke(124);
+            Console.WriteLine("obj Value=" + obj.Value);
+
         }
         public static void DelegateExtTest03()
         {

--- a/TestCases/DelegateExtTest.cs
+++ b/TestCases/DelegateExtTest.cs
@@ -52,7 +52,7 @@ namespace TestCases
             var obj = new DelegateExtObj();
             ILRuntimeTest.TestFramework.DelegateTest.IntDelegateTest += obj.IntTest;
             ILRuntimeTest.TestFramework.DelegateTest.IntDelegateTest += obj.IntTest2;
-
+            ILRuntimeTest.TestFramework.DelegateTest.IntDelegateTest(123);
 
         }
 

--- a/TestCases/TestCases.csproj
+++ b/TestCases/TestCases.csproj
@@ -45,6 +45,7 @@
     <Compile Include="AsyncAwaitTest.cs" />
     <Compile Include="CLRBindingTest.cs" />
     <Compile Include="DelegateInnerTest.cs" />
+    <Compile Include="DelegateExtTest.cs" />
     <Compile Include="GenericMethodTest.cs" />
     <Compile Include="JsonTest.cs" />
     <Compile Include="StaticTest.cs" />


### PR DESCRIPTION
当使用一个扩展方法作为委托使用时，会出现DelegateAdapter报空问题
测试用例 DelegateExtTest.cs