### PR TITLE
修复 特性获取 与 绑定泛型参数错误

### DIFF
--- a/ILRuntime/CLR/Method/ILMethod.cs
+++ b/ILRuntime/CLR/Method/ILMethod.cs
@@ -365,7 +365,7 @@ namespace ILRuntime.CLR.Method
         {
             get
             {
-                if (def.HasParameters && parameters == null)
+                if (def.HasParameters || parameters == null)
                 {
                     InitParameters();
                 }

--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -135,11 +135,14 @@ namespace ILRuntime.Reflection
             List<object> res = new List<object>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
-                if (attributeTypes[i].Equals(attributeType))
+                if (attributeTypes[i].Equals(attributeType)||attributeType.IsAssignableFrom ( attributeTypes[i] ))
                     res.Add(customAttributes[i]);
             }
             return res.ToArray();
         }
+        public Object GetCustomAttribute ( Type oType, Boolean inherit ) => this.GetCustomAttributes ( oType, inherit ).FirstOrDefault ();
+        public T GetCustomAttribute<T> ( Boolean inherit ) where T : System.Attribute => this.GetCustomAttributes<T> ( inherit ).FirstOrDefault ();
+        public T [] GetCustomAttributes<T> ( Boolean inherit ) where T : System.Attribute => this.GetCustomAttributes ( typeof ( T ), inherit ).Select ( t => ( T ) t ).ToArray ();
 
         public override MethodImplAttributes GetMethodImplementationFlags()
         {

--- a/ILRuntime/Runtime/Extensions.cs
+++ b/ILRuntime/Runtime/Extensions.cs
@@ -375,7 +375,7 @@ namespace ILRuntime.Runtime
                     if (q.IsGenericType)
                     {
                         var t1 = type.GetGenericTypeDefinition();
-                        var t2 = type.GetGenericTypeDefinition();
+                        var t2 = q.GetGenericTypeDefinition();
                         if (t1 == t2)
                         {
                             var argA = type.GetGenericArguments();


### PR DESCRIPTION
1、修复 通过父对象获取特性
2、修复 绑定参数是泛型类型时错误