### PR TITLE
修复使用扩展方法不能获取到指定的Attibute的问题

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeFieldInfo.cs
@@ -154,7 +154,7 @@ namespace ILRuntime.Reflection
             if (customAttributes == null)
                 InitializeCustomAttribute();
 
-            List<object> res = new List<object>();
+            List<Attribute> res = new List<Attribute>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
                 if (attributeTypes[i].Equals(attributeType) || attributeTypes[i].IsSubclassOf(attributeType))

--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -132,7 +132,7 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
-            List<object> res = new List<object>();
+            List<Attribute> res = new List<Attribute>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
                 if (attributeTypes[i].Equals(attributeType))

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -219,9 +219,9 @@ namespace ILRuntime.Reflection
                 InitializeCustomAttribute();
             if (inherit && BaseType != null)
             {
-                List<object> result = new List<object>();
+                List<Attribute> result = new List<Attribute>();
                 result.AddRange(customAttributes);
-                result.AddRange(BaseType.GetCustomAttributes(inherit));
+                result.AddRange(BaseType.GetCustomAttributes(inherit) as Attribute[]);
                 return result.ToArray();
             }
             return customAttributes;
@@ -231,7 +231,7 @@ namespace ILRuntime.Reflection
         {
             if (customAttributes == null)
                 InitializeCustomAttribute();
-            List<object> res = new List<object>();
+            List<Attribute> res = new List<Attribute>();
             for (int i = 0; i < customAttributes.Length; i++)
             {
                 if (attributeTypes[i].Equals((object)attributeType))
@@ -239,7 +239,7 @@ namespace ILRuntime.Reflection
             }
             if (inherit && BaseType != null)
             {
-                res.AddRange(BaseType.GetCustomAttributes(attributeType, inherit));
+                res.AddRange(BaseType.GetCustomAttributes(attributeType, inherit) as Attribute[]);
             }
             return res.ToArray();
         }

--- a/TestCases/TestLL.cs
+++ b/TestCases/TestLL.cs
@@ -22,11 +22,15 @@ namespace TestCases
         
     }
 
-
+    [XmlFieldMapAttribute]
     public class TestLL
     {
         [XmlFieldMapAttribute]
         public Dictionary<int, int> tempMap = new Dictionary<int, int>();
+        [XmlFieldMapAttribute]
+        public Dictionary<int, int> tempMapProperty => tempMap;
+        [XmlFieldMapAttribute]
+        public Dictionary<int, int> GetTempMap() => tempMap;
 
         public static string TestIsAssignableFrom()
         {
@@ -58,6 +62,45 @@ namespace TestCases
             Console.WriteLine(fieldInfo.IsDefined(typeof(XmlFieldListAttribute), true));
 
             return "Test finish!";
+        }
+
+        public static void TestFieldGetCustomAttribte()
+        {
+            FieldInfo fieldInfo = typeof(TestLL).GetField("tempMap");
+
+            Console.WriteLine($"test GetCustomAttribute using System.Reflection.CustomAttributeExtensions.GetCustomAttribute");
+            var attribute = fieldInfo.GetCustomAttribute(typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL.tempMap has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
+
+            Console.WriteLine($"test GetCustomAttribute using System.Attribute.GetCustomAttribute");
+            attribute = Attribute.GetCustomAttribute(fieldInfo, typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL.tempMap has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
+        }
+
+        public static void TestTypeGetCustomAttribte()
+        {
+            var type = typeof(TestLL);
+
+            Console.WriteLine($"test GetCustomAttribute using System.Reflection.CustomAttributeExtensions.GetCustomAttribute");
+            var attribute = type.GetCustomAttribute(typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
+
+            Console.WriteLine($"test GetCustomAttribute using System.Attribute.GetCustomAttribute");
+            attribute = Attribute.GetCustomAttribute(type, typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
+        }
+
+        public static void TestMethodGetCustomAttribte()
+        {
+            var methodInfo = typeof(TestLL).GetMethod("GetTempMap");
+
+            Console.WriteLine($"test GetCustomAttribute using System.Reflection.CustomAttributeExtensions.GetCustomAttribute");
+            var attribute = methodInfo.GetCustomAttribute(typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL.GetTempMap has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
+
+            Console.WriteLine($"test GetCustomAttribute using System.Attribute.GetCustomAttribute");
+            attribute = Attribute.GetCustomAttribute(methodInfo, typeof(XmlFieldMapAttribute), true);
+            Console.WriteLine($"TestLL.GetTempMap has {(attribute == null ? "NO " : "")}XmlFieldMapAttribute");
         }
     }
 }


### PR DESCRIPTION
System.Reflection.CustomAttributeExtensions.GetCustomAttribute与System.Attribute.GetCustomAttribute不能获取到指定的Attibute.原因为object[]不能强转为Attribute[],在重写相关方法时返回Attribute[]即可解决这个问题。