### PR TITLE
修复ILType.InitializeFields()方法中可能出现的空引用

### DIFF
--- a/ILRuntime/CLR/TypeSystem/ILType.cs
+++ b/ILRuntime/CLR/TypeSystem/ILType.cs
@@ -1082,6 +1082,7 @@ namespace ILRuntime.CLR.TypeSystem
             {
                 fieldTypes = new IType [ 0 ];
                 fieldDefinitions = new FieldDefinition [ 0 ];
+                return;
             }
             fieldTypes = new IType [ definition.Fields.Count ];
             fieldDefinitions = new FieldDefinition [ definition.Fields.Count ];


### PR DESCRIPTION
![捕获](https://user-images.githubusercontent.com/91198419/151654852-d6cfed61-3b4e-4e93-9c68-78953b845c4a.PNG)
增加一行return避免可能出现的空引用异常