### PR TITLE
修复Stfld与Ldfld当对象为适配器时的异常

### DIFF
--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2106,10 +2106,10 @@ namespace ILRuntime.Runtime.Intepreter
                                         if (obj != null)
                                         {
                                             ILTypeInstance instance = null;
-                                            if (obj is ILTypeInstance ilTypeInstance)
-                                                instance = ilTypeInstance;
-                                            else if (obj is CrossBindingAdaptorType crossBindingAdaptorType)
-                                                instance = crossBindingAdaptorType.ILInstance;
+                                            if (obj is ILTypeInstance)
+                                                instance = obj as ILTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType)
+                                                instance = (obj as CrossBindingAdaptorType).ILInstance;
                                             if (instance != null)
                                             {
                                                 val = esp - 1;
@@ -2242,10 +2242,10 @@ namespace ILRuntime.Runtime.Intepreter
                                         if (obj != null)
                                         {
                                             ILTypeInstance instance = null;
-                                            if (obj is ILTypeInstance ilTypeInstance)
-                                                instance = ilTypeInstance;
-                                            else if (obj is CrossBindingAdaptorType crossBindingAdaptorType)
-                                                instance = crossBindingAdaptorType.ILInstance;
+                                            if (obj is ILTypeInstance)
+                                                instance = obj as ILTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType)
+                                                instance = (obj as CrossBindingAdaptorType).ILInstance;
                                             if (instance != null)
                                                 instance.PushToStack((int)ip->TokenLong, ret, this, mStack);
                                             else

--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2105,9 +2105,13 @@ namespace ILRuntime.Runtime.Intepreter
 
                                         if (obj != null)
                                         {
-                                            if (obj is ILTypeInstance)
+                                            ILTypeInstance instance = null;
+                                            if (obj is ILTypeInstance ilTypeInstance)
+                                                instance = ilTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType crossBindingAdaptorType)
+                                                instance = crossBindingAdaptorType.ILInstance;
+                                            if (instance != null)
                                             {
-                                                ILTypeInstance instance = obj as ILTypeInstance;
                                                 val = esp - 1;
                                                 instance.AssignFromStack((int)ip->TokenLong, val, AppDomain, mStack);
                                             }
@@ -2237,11 +2241,13 @@ namespace ILRuntime.Runtime.Intepreter
                                         Free(ret);
                                         if (obj != null)
                                         {
-                                            if (obj is ILTypeInstance)
-                                            {
-                                                ILTypeInstance instance = obj as ILTypeInstance;
+                                            ILTypeInstance instance = null;
+                                            if (obj is ILTypeInstance ilTypeInstance)
+                                                instance = ilTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType crossBindingAdaptorType)
+                                                instance = crossBindingAdaptorType.ILInstance;
+                                            if (instance != null)
                                                 instance.PushToStack((int)ip->TokenLong, ret, this, mStack);
-                                            }
                                             else
                                             {
                                                 //var t = obj.GetType();

--- a/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
+++ b/ILRuntime/Runtime/Intepreter/RegisterVM/ILIntepreter.Register.cs
@@ -2965,11 +2965,13 @@ namespace ILRuntime.Runtime.Intepreter
 
                                         if (obj != null)
                                         {
+                                            ILTypeInstance instance = null;
                                             if (obj is ILTypeInstance)
-                                            {
-                                                ILTypeInstance instance = obj as ILTypeInstance;
+                                                instance = obj as ILTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType)
+                                                instance = (obj as CrossBindingAdaptorType).ILInstance;
+                                            if (instance != null)
                                                 instance.AssignFromStack((int)ip->OperandLong, reg2, AppDomain, mStack);
-                                            }
                                             else
                                             {
                                                 var t = obj.GetType();
@@ -3068,11 +3070,13 @@ namespace ILRuntime.Runtime.Intepreter
                                         obj = RetriveObject(objRef, mStack);
                                         if (obj != null)
                                         {
+                                            ILTypeInstance instance = null;
                                             if (obj is ILTypeInstance)
-                                            {
-                                                ILTypeInstance instance = obj as ILTypeInstance;
+                                                instance = obj as ILTypeInstance;
+                                            else if (obj is CrossBindingAdaptorType)
+                                                instance = (obj as CrossBindingAdaptorType).ILInstance;
+                                            if (instance != null)
                                                 instance.CopyToRegister((int)ip->OperandLong, ref info, ip->Register1);//Check #345
-                                            }
                                             else
                                             {
                                                 //var t = obj.GetType();

--- a/TestCases/InheritanceTest.cs
+++ b/TestCases/InheritanceTest.cs
@@ -292,6 +292,26 @@ namespace TestCases
             }
         }
 
+        CrossClass crossClass;
+        public static void InheritanceTest21()
+        {
+            var inheritanceTest = new InheritanceTest();
+            var dic = new Dictionary<int, CrossClass>();
+            dic.Add(1, new CrossClass());
+            dic.TryGetValue(1, out inheritanceTest.crossClass);
+            Console.WriteLine("InheritanceTest21:classA is " + inheritanceTest.crossClass.classA);
+        }
+
+        public static void InheritanceTest22()
+        {
+            var inheritanceTest = new InheritanceTest();
+            var dic = new Dictionary<int, CrossClass>();
+            dic.Add(1, new CrossClass());
+            dic.TryGetValue(1, out inheritanceTest.crossClass);
+            inheritanceTest.crossClass.classA = new ClassA();
+            Console.WriteLine("InheritanceTest21:classA is " + inheritanceTest.crossClass.classA);
+        }
+
         class TestExplicitInterface : IDisposable
         {
             public bool Called { get; set; }


### PR DESCRIPTION
在测试用例源码文件`InheritanceTest.cs`中增加如下2个用例
```C#
CrossClass crossClass;
public static void InheritanceTest21()
{
    var inheritanceTest = new InheritanceTest();
    var dic = new Dictionary<int, CrossClass>();
    dic.Add(1, new CrossClass());
    dic.TryGetValue(1, out inheritanceTest.crossClass);
    Console.WriteLine("InheritanceTest21:classA is " + inheritanceTest.crossClass.classA);
}

public static void InheritanceTest22()
{
    var inheritanceTest = new InheritanceTest();
    var dic = new Dictionary<int, CrossClass>();
    dic.Add(1, new CrossClass());
    dic.TryGetValue(1, out inheritanceTest.crossClass);
    inheritanceTest.crossClass.classA = new ClassA();
    Console.WriteLine("InheritanceTest21:classA is " + inheritanceTest.crossClass.classA);
}
```
其中`InheritanceTest21`报如下异常
```
无法将类型为“ILRuntime.CLR.TypeSystem.ILType”的对象强制转换为类型“ILRuntime.CLR.TypeSystem.CLRType”。
Local Variables:
InheritanceTest inheritanceTest = TestCases.InheritanceTest, Dictionary`2 dic = System.Collections.Generic.Dictionary`2[System.Int32,ILRuntimeTest.TestFramework.TestClass3Adaptor+Adaptor]

IL_0033: ldfld TestCases.InheritanceTest/ClassA TestCases.InheritanceTest/CrossClass::classA
at TestCases.InheritanceTest.InheritanceTest21() (at C:/Users/Administrator/source/repos/Endures/ILRuntime/TestCases/InheritanceTest.cs:302)

System.InvalidCastException: 无法将类型为“ILRuntime.CLR.TypeSystem.ILType”的对象强制转换为类型“ILRuntime.CLR.TypeSystem.CLRType”。
   在 ILRuntime.Runtime.Intepreter.ILIntepreter.Execute(ILMethod method, StackObject* esp, Boolean& unhandledException) 位置 C:\Users\Administrator\source\repos\Endures\ILRuntime\ILRuntime\Runtime\Intepreter\ILIntepreter.cs:行号 2252
```
原因为未处理局部变量`obj`为适配器类型(`CrossBindingAdaptorType`)的情况
用例`InheritanceTest22`同理