### PR TITLE
索引器重载时属性的GetMethod和SetMethod不正确

### DIFF
--- a/ILRuntime/Reflection/ILRuntimeConstructorInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeConstructorInfo.cs
@@ -21,7 +21,7 @@ namespace ILRuntime.Reflection
             for(int i = 0; i < m.ParameterCount; i++)
             {
                 var pd = m.Definition.Parameters[i];
-                parameters[i] = new ILRuntimeParameterInfo(pd, m.Parameters[i], this);
+                parameters[i] = new ILRuntimeParameterInfo(pd, m.Parameters[i], this, m.AppDomain);
             }
         }
 

--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -250,5 +250,10 @@ namespace ILRuntime.Reflection
             return del.Delegate;
         }
 #endif
+
+        public override string ToString()
+        {
+            return definition == null ? base.ToString() : definition.ToString();
+        }
     }
 }

--- a/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeMethodInfo.cs
@@ -31,7 +31,7 @@ namespace ILRuntime.Reflection
             for (int i = 0; i < m.ParameterCount; i++)
             {
                 var pd = m.Definition.Parameters[i];
-                parameters[i] = new ILRuntimeParameterInfo(pd, m.Parameters[i], this);
+                parameters[i] = new ILRuntimeParameterInfo(pd, m.Parameters[i], this, appdomain);
             }
         }
 

--- a/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
@@ -11,24 +11,94 @@ namespace ILRuntime.Reflection
 {
     public class ILRuntimeParameterInfo : ParameterInfo
     {
-        IType type;
-        MethodBase method;
-        Mono.Cecil.ParameterDefinition definition;
+        public IType IType { get; private set; }
+        public ILRuntime.Runtime.Enviorment.AppDomain AppDomain{ get; private set; }
 
-        public ILRuntimeParameterInfo(Mono.Cecil.ParameterDefinition definition, IType type, MethodBase method)
+        Mono.Cecil.ParameterDefinition definition;
+        Attribute[] customAttributes;
+        Type[] attributeTypes;
+
+        public ILRuntimeParameterInfo(Mono.Cecil.ParameterDefinition definition, IType type, MemberInfo member, ILRuntime.Runtime.Enviorment.AppDomain appdomain)
         {
-            this.type = type;
-            this.method = method;
-            this.MemberImpl = method;
+            this.IType = type;
             this.definition = definition;
+            this.AppDomain = appdomain;
+
+            AttrsImpl = (ParameterAttributes)definition.Attributes;
+            ClassImpl = type.ReflectionType;
+            DefaultValueImpl = definition.Constant;
+            MemberImpl = member;
             NameImpl = definition.Name;
+            PositionImpl = definition.Index;
         }
-        public override Type ParameterType
+
+        void InitializeCustomAttribute()
         {
-            get
+            customAttributes = new Attribute[definition.CustomAttributes.Count];
+            attributeTypes = new Type[customAttributes.Length];
+            for (int i = 0; i < definition.CustomAttributes.Count; i++)
             {
-                return type.ReflectionType;
+                var attribute = definition.CustomAttributes[i];
+                var at = AppDomain.GetType(attribute.AttributeType, null, null);
+                try
+                {
+                    Attribute ins = attribute.CreateInstance(at, AppDomain) as Attribute;
+
+                    attributeTypes[i] = at.ReflectionType;
+                    customAttributes[i] = ins;
+                }
+                catch
+                {
+                    attributeTypes[i] = typeof(Attribute);
+                }
             }
+        }
+
+        public override bool HasDefaultValue
+        {
+            get { return definition.HasDefault; }
+        }
+
+        public override object DefaultValue
+        {
+            get { return DefaultValueImpl; }
+        }
+
+        public override object RawDefaultValue
+        {
+            get { return DefaultValueImpl; }
+        }
+
+        public override int MetadataToken
+        {
+            get { return definition.MetadataToken.ToInt32(); }
+        }
+
+        public override object[] GetCustomAttributes(bool inherit)
+        {
+            if (customAttributes == null)
+                InitializeCustomAttribute();
+
+            return customAttributes;
+        }
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            if (customAttributes == null)
+                InitializeCustomAttribute();
+            List<Attribute> res = new List<Attribute>();
+            for (int i = 0; i < customAttributes.Length; i++)
+            {
+                if (attributeTypes[i].Equals(attributeType))
+                    res.Add(customAttributes[i]);
+            }
+            return res.ToArray();
+        }
+
+        public override bool IsDefined(Type attributeType, bool inherit)
+        {
+            var result = GetCustomAttributes(attributeType, inherit);
+            return result != null && result.Length > 0;
         }
     }
 }

--- a/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimeParameterInfo.cs
@@ -100,5 +100,10 @@ namespace ILRuntime.Reflection
             var result = GetCustomAttributes(attributeType, inherit);
             return result != null && result.Length > 0;
         }
+
+        public override string ToString()
+        {
+            return definition == null ? base.ToString() : definition.ToString();
+        }
     }
 }

--- a/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
@@ -270,5 +270,10 @@ namespace ILRuntime.Reflection
             else
                 throw new ArgumentException("Index count mismatch");
         }
+
+        public override string ToString()
+        {
+            return definition == null ? base.ToString() : definition.ToString();
+        }
     }
 }

--- a/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
+++ b/ILRuntime/Reflection/ILRuntimePropertyInfo.cs
@@ -16,6 +16,7 @@ namespace ILRuntime.Reflection
         ILType dType;
         Mono.Cecil.PropertyDefinition definition;
         ILRuntime.Runtime.Enviorment.AppDomain appdomain;
+        ILRuntimeParameterInfo[] parameters;
 
         Attribute[] customAttributes;
         Type[] attributeTypes;
@@ -64,6 +65,13 @@ namespace ILRuntime.Reflection
             this.definition = definition;
             this.dType = dType;
             appdomain = dType.AppDomain;
+            parameters = new ILRuntimeParameterInfo[definition.Parameters.Count];
+            for (int i = 0; i < definition.Parameters.Count; i++)
+            {
+                var pd = definition.Parameters[i];
+                var parameterType = dType.AppDomain.GetType(pd.ParameterType, null, null);
+                parameters[i] = new ILRuntimeParameterInfo(pd, parameterType, this, appdomain);
+            }
         }
 
         void InitializeCustomAttribute()
@@ -211,7 +219,7 @@ namespace ILRuntime.Reflection
 
         public override ParameterInfo[] GetIndexParameters()
         {
-            return new ParameterInfo[0];
+            return parameters;
         }
 
         public override MethodInfo GetSetMethod(bool nonPublic)

--- a/ILRuntime/Reflection/ILRuntimeType.cs
+++ b/ILRuntime/Reflection/ILRuntimeType.cs
@@ -72,9 +72,13 @@ namespace ILRuntime.Reflection
                 ILRuntimePropertyInfo pi = new ILRuntimePropertyInfo(pd, type);
                 properties[i] = pi;
                 if (pd.GetMethod != null)
-                    pi.Getter = type.GetMethod(pd.GetMethod.Name, pd.GetMethod.Parameters.Count) as ILMethod;
+                {
+                    pi.Getter = type.GetMethod(pd.GetMethod.Name, pd.GetMethod.Parameters.Select(p => type.AppDomain.GetType(p.ParameterType, null, null)).ToList(), null) as ILMethod;
+                }
                 if (pd.SetMethod != null)
-                    pi.Setter = type.GetMethod(pd.SetMethod.Name, pd.SetMethod.Parameters.Count) as ILMethod;
+                {
+                    pi.Setter = type.GetMethod(pd.SetMethod.Name, pd.SetMethod.Parameters.Select(p => type.AppDomain.GetType(p.ParameterType, null, null)).ToList(), null) as ILMethod;
+                }
             }
         }
 

--- a/TestCases/ReflectionTest.cs
+++ b/TestCases/ReflectionTest.cs
@@ -160,6 +160,31 @@ namespace TestCases
                 throw new Exception("attr.Name != Example");
             }
         }
+
+        public static void TestPropertyIndexParametersInfo()
+        {
+            var pi = typeof(TestCls).GetProperty("Ccc");
+            List<string> parametersInfo = new List<string>();
+            foreach (var p in pi.GetIndexParameters())
+            {
+                parametersInfo.Add(string.Format("[{0}, type:{1}, default value:{2}]", p.Name, p.ParameterType.FullName, p.DefaultValue));
+            }
+            Console.WriteLine("Property:TestCls.Ccc, parameters:" + string.Join(",", parametersInfo));
+        }
+
+        public static void TestMethodParametersInfo()
+        {
+            var md = typeof(TestCls).GetMethod("Do");
+            List<string> parametersInfo = new List<string>();
+            foreach (var p in md.GetParameters())
+            {
+                parametersInfo.Add(string.Format("[{0}, type:{1}, is out:{2}, default value:{3}]", p.Name, p.ParameterType.FullName, p.IsOut, p.DefaultValue));
+            }
+            var att = md.GetParameters()[0].GetCustomAttributes(true);
+            Console.WriteLine("Method:TestCls.Do, parameters:" + string.Join(",", parametersInfo));
+            Console.WriteLine("Method:TestCls.Do, first parameter has custom attribute:" + ((Attribute)att[0]).GetType().FullName);
+        }
+
         [Obsolete("gasdgas")]
         public class TestCls
         {
@@ -178,6 +203,17 @@ namespace TestCases
             public static void bar()
             {
                 Console.WriteLine("bar");
+            }
+
+            [System.Runtime.CompilerServices.IndexerName("Ccc")]
+            public int this[int i]
+            {
+                get { return aa % i; }
+            }
+
+            public static void Do([Test] int i, out int ii, string s = "123")
+            {
+                ii = 0;
             }
         }
 

--- a/TestCases/ReflectionTest.cs
+++ b/TestCases/ReflectionTest.cs
@@ -163,13 +163,18 @@ namespace TestCases
 
         public static void TestPropertyIndexParametersInfo()
         {
-            var pi = typeof(TestCls).GetProperty("Ccc");
-            List<string> parametersInfo = new List<string>();
-            foreach (var p in pi.GetIndexParameters())
+            foreach (var pi in typeof(TestCls).GetProperties())
             {
-                parametersInfo.Add(string.Format("[{0}, type:{1}, default value:{2}]", p.Name, p.ParameterType.FullName, p.DefaultValue));
+                if (pi.GetIndexParameters().Length <= 0) // 只获取索引器
+                    continue;
+
+                List<string> parametersInfo = new List<string>();
+                foreach (var p in pi.GetIndexParameters())
+                {
+                    parametersInfo.Add(string.Format("[{0}, type:{1}, default value:{2}]", p.Name, p.ParameterType.FullName, p.DefaultValue));
+                }
+                Console.WriteLine(string.Format("Property:{0}.{1}, parameters:{2}, getter:{3}", pi.DeclaringType.FullName, pi.Name, string.Join(",", parametersInfo), pi.GetMethod.ToString()));
             }
-            Console.WriteLine("Property:TestCls.Ccc, parameters:" + string.Join(",", parametersInfo));
         }
 
         public static void TestMethodParametersInfo()
@@ -206,9 +211,15 @@ namespace TestCases
             }
 
             [System.Runtime.CompilerServices.IndexerName("Ccc")]
-            public int this[int i]
+            public bool this[int i]
             {
-                get { return aa % i; }
+                get { return true; }
+            }
+
+            [System.Runtime.CompilerServices.IndexerName("Ccc")]
+            public bool this[string s]
+            {
+                get { return false; }
             }
 
             public static void Do([Test] int i, out int ii, string s = "123")


### PR DESCRIPTION
如下热更代码定义了2个重载的索引器
```C#
public class TestCls
{
    [System.Runtime.CompilerServices.IndexerName("Ccc")]
    public bool this[int i]
    {
        get { return true; }
    }

    [System.Runtime.CompilerServices.IndexerName("Ccc")]
    public bool this[string s]
    {
        get { return false; }
    }
}
```
那么这2个索引器属性的GetMethod和SetMethod全部为整形参数索引器的GetMethod和SetMethod。原因为源码中只使用方法名称获取getter和setter
https://github.com/Ourpalm/ILRuntime/blob/dab342ebb6e62facf68e1941ccd7bd35bf6c114b/ILRuntime/Reflection/ILRuntimeType.cs#L74-L77
将这部分代码修改为使用方法名称和参数类型去匹配
```C#
if (pd.GetMethod != null)
{
    pi.Getter = type.GetMethod(pd.GetMethod.Name, pd.GetMethod.Parameters.Select(p => type.AppDomain.GetType(p.ParameterType, null, null)).ToList(), null) as ILMethod;
}
if (pd.SetMethod != null)
{
    pi.Setter = type.GetMethod(pd.SetMethod.Name, pd.SetMethod.Parameters.Select(p => type.AppDomain.GetType(p.ParameterType, null, null)).ToList(), null) as ILMethod;
}
```
已增加测试用例TestCases.ReflectionTest.TestPropertyIndexParametersInfo与TestCases.ReflectionTest.TestMethodParametersInfo