### PR TITLE
修复AppDomain无法被GC的bug

### DIFF
--- a/ILRuntime/Runtime/Enviorment/AppDomain.cs
+++ b/ILRuntime/Runtime/Enviorment/AppDomain.cs
@@ -208,6 +208,7 @@ namespace ILRuntime.Runtime.Enviorment
 
         public void Dispose()
         {
+            this.ClearTypeFlags();
             debugService.StopDebugService();
             jitWorker.Dispose();
         }


### PR DESCRIPTION
在`GetTypeFlags`方法中通过判断`Type`是否是`ILRuntimeWrapperType`从而将`ILRuntimeWrapperType`和`RuntimeType`分开缓存对应值，最后在`AppDomain`的`Dispose`方法中进行统一清理, 避免AppDomain被static成员引用导致无法GC的问题。