### PR TITLE
修复跨域继承的类型会被误认为CLR中的兄弟类型

### DIFF
--- a/ILRuntime/CLR/TypeSystem/CLRType.cs
+++ b/ILRuntime/CLR/TypeSystem/CLRType.cs
@@ -903,7 +903,7 @@ namespace ILRuntime.CLR.TypeSystem
                 if (type is ILType)
                     return false;
                 Type cT = type != null ? type.TypeForCLR : typeof(object);
-                return TypeForCLR.IsAssignableFrom(cT);
+                return cT.IsAssignableFrom(TypeForCLR);
             }
         }
 

--- a/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
@@ -373,15 +373,6 @@ namespace ");
                 if (isByRef)
                     sb.Append(".MakeByRefType()");
             }
-            if (returnType != typeof(void))
-            {
-                if (!first)
-                    sb.Append(", ");
-                string clsName, realClsName;
-                bool isByRef;
-                returnType.GetClassName(out clsName, out realClsName, out isByRef, true);
-                sb.Append(realClsName);
-            }
             return sb.ToString();
         }
 

--- a/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
@@ -531,7 +531,7 @@ namespace ");
             sb.AppendLine("                    }");
             if (hasReturn)
                 sb.AppendLine(@"                    else
-                        return default(TResult);");
+                        return default;");
             sb.AppendLine(@"                }
 
                 public override void Invoke(ILTypeInstance instance)

--- a/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
@@ -322,7 +322,7 @@ namespace ");
             var returnType = info.ReturnType;
             if (returnType.IsByRef)
                 returnType = returnType.GetElementType();
-            if (returnType.IsNotPublic || returnType.IsNested && !returnType.IsNestedPublic)
+            if (returnType.IsNotPublic || returnType.IsNested && !returnType.IsNestedPublic && !returnType.IsNestedFamily && !returnType.IsNestedFamORAssem)
                 return true;
 
             return false;

--- a/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
@@ -593,7 +593,8 @@ namespace ");
             {
                 if (p.IsOut)
                 {
-                    sb.AppendLine(string.Format("                    {0} = default({1});", p.Name, p.ParameterType.GetElementType().FullName));
+                    p.ParameterType.GetClassName(out var clsName, out var realClsName, out var isByRef, true);
+                    sb.AppendLine(string.Format("                    {0} = default({1});", p.Name, realClsName));
                 }
             }
         }

--- a/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
+++ b/ILRuntime/Runtime/Enviorment/CrossBindingCodeGenerator.cs
@@ -18,7 +18,8 @@ namespace ILRuntime.Runtime.Enviorment
             public Type ReturnType;
             public string GetterBody;
             public string SettingBody;
-            public string Modifier;
+            public string GetterModifier;
+            public string SettingModifier;
             public string OverrideString;
         }
 
@@ -188,7 +189,6 @@ namespace ");
                 }
                 else
                 {
-                    pInfo.Modifier = modifier;
                     pInfo.OverrideString = overrideStr;
                 }
                 if (!i.IsAbstract)
@@ -221,10 +221,12 @@ namespace ");
                 {
                     if (isGetter)
                     {
+                        pInfo.GetterModifier = modifier;
                         pInfo.GetterBody = sb.ToString();
                     }
                     else
                     {
+                        pInfo.SettingModifier = modifier;
                         pInfo.SettingBody = sb.ToString();
                     }
                     sb = oriBuilder;
@@ -243,11 +245,13 @@ namespace ");
                 string clsName, realClsName;
                 bool isByRef;
                 pInfo.ReturnType.GetClassName(out clsName, out realClsName, out isByRef, true);
-                sb.AppendLine(string.Format("            {0} {3}{1} {2}", pInfo.Modifier, realClsName, pInfo.Name, pInfo.OverrideString));
+                var modifier = pInfo.GetterModifier == "public" || string.IsNullOrEmpty(pInfo.SettingModifier) ? pInfo.GetterModifier : pInfo.SettingModifier;
+                sb.AppendLine(string.Format("            {0} {3}{1} {2}", modifier, realClsName, pInfo.Name, pInfo.OverrideString));
                 sb.AppendLine("            {");
                 if (!string.IsNullOrEmpty(pInfo.GetterBody))
                 {
-                    sb.AppendLine("            get");
+                    if (pInfo.GetterModifier == modifier) sb.AppendLine("            get");
+                    else sb.AppendLine($"            {pInfo.GetterModifier} get");
                     sb.AppendLine("            {");
                     sb.AppendLine(pInfo.GetterBody);
                     sb.AppendLine("            }");
@@ -255,7 +259,8 @@ namespace ");
                 }
                 if (!string.IsNullOrEmpty(pInfo.SettingBody))
                 {
-                    sb.AppendLine("            set");
+                    if (pInfo.SettingModifier == modifier) sb.AppendLine("            set");
+                    else sb.AppendLine($"            {pInfo.SettingModifier} set");
                     sb.AppendLine("            {");
                     sb.AppendLine(pInfo.SettingBody);
                     sb.AppendLine("            }");


### PR DESCRIPTION
这里被写反了，这个提交修复如下类型判断错误

```
主工程
基类 public class Base {}
子类 public class Derive {}

热更工程
子类 public class DeriveHotfix {}

void Function(DeriveHotfix deriveHotfix)
{
    Debug.Log(deriveHotfix is Derive); // true
    Debug.Log(deriveHotfix is DeriveHotfix); // true
}
```