### PR TITLE
修复包含 new 声明的 Property 的类生成绑定代码过程报错

### DIFF
--- a/ILRuntime/Runtime/CLRBinding/BindingGeneratorExtensions.cs
+++ b/ILRuntime/Runtime/CLRBinding/BindingGeneratorExtensions.cs
@@ -56,7 +56,7 @@ namespace ILRuntime.Runtime.CLRBinding
                     }
                     else
                         ts = new Type[0];
-                    var prop = type.GetProperty(t[1], ts);
+                    var prop = type.GetProperties().FirstOrDefault(p => p.Name == t[1] && p.GetIndexParameters().Select(pp => pp.ParameterType).SequenceEqual(ts));
                     if (prop == null)
                     {
                         return true;


### PR DESCRIPTION
当一个类有一个用 new 修饰的 Property 时，生成绑定代码时原代码会报错