### PR TITLE
修复将跨域继承的子类的成员函数作为委托传递时报异常

### DIFF
--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -2829,6 +2829,8 @@ namespace ILRuntime.Runtime.Intepreter
                                                 var ilMethod = mi as ILMethod;
                                                 if (ilMethod != null)
                                                 {
+                                                    if (ins is CrossBindingAdaptorType)
+                                                        ins = ((CrossBindingAdaptorType)ins).ILInstance;
                                                     dele = domain.DelegateManager.FindDelegateAdapter((CLRType)cm.DeclearingType, (ILTypeInstance)ins, ilMethod);
                                                 }
                                                 else


### PR DESCRIPTION
修复如下情况：

主工程:
class Base
{
  public void Test(Action action)
  {
  }
}

热更工程：

class Sub : Base
{
  Base _base;
  void SubTest()
  {
    _base.Test(()=>SubTest2()); // 此行报错
  }
  void SubTest2()
  {
  }
}