### PR TITLE
Add CrossBindingAdaptorType support for LoadFromFieldReference

### DIFF
--- a/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
+++ b/ILRuntime/Runtime/Intepreter/ILIntepreter.cs
@@ -5486,6 +5486,10 @@ namespace ILRuntime.Runtime.Intepreter
             {
                 ((ILTypeInstance)obj).PushToStack(idx, dst, this, mStack);
             }
+            else if (obj is CrossBindingAdaptorType)
+            {
+                ((CrossBindingAdaptorType)obj).ILInstance.PushToStack(idx, dst, this, mStack);
+            }
             else
             {
                 CLRType t = AppDomain.GetType(obj.GetType()) as CLRType;


### PR DESCRIPTION
![a](https://github.com/user-attachments/assets/edde238d-0084-4b09-bb13-a89559691323)
In some case, this object may be of type CrossBindingAdaptorType, which can result loading null value from the field reference. In my case adding this code solve the problem.